### PR TITLE
Introduce SampleList interface without actual functional change (#293)

### DIFF
--- a/src/main/java/org/opensearch/tsdb/core/model/SampleList.java
+++ b/src/main/java/org/opensearch/tsdb/core/model/SampleList.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.core.model;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Customized list representation of samples, this interface tries to promote usage of raw values and timestamps
+ * instead of a {@link Sample} object due to Java's object overhead
+ */
+public interface SampleList extends Iterable<Sample> {
+
+    /**
+     * Get the size of this list, should be a fast operation unless specifically noticed
+     * This does not guarantee the returned number is for non-NaN or not, the only guarantee
+     * is that any index: 0 &le; index &lt; size() is an valid input of getXX methods
+     * <br>
+     * Also what returned by {@link #iterator()} is expected to be able to call {@link Iterator#next()}
+     * size() times
+     */
+    int size();
+
+    /**
+     * @return whether the list is empty
+     */
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * Get the sample value at specific index, could be {@link Double#NaN}
+     * @param index should be less than what {@link #size()} returns
+     */
+    double getValue(int index);
+
+    /**
+     * Get the timestamp value at specific index
+     * @param index should be less than what {@link #size()} returns
+     */
+    long getTimestamp(int index);
+
+    /**
+     * Get the {@link Sample} representation at specific index
+     * TODO: This API exists purely for compatibility, should be removed in the next/future PR
+     */
+    Sample getSample(int index);
+
+    /**
+     * Get the sample type for this list, by default we assume the whole list is of the same type
+     */
+    SampleType getSampleType();
+
+    /**
+     * Like {@link List#subList(int, int)}, the returned list should be a complete copy so that any new
+     * modification will not reflect on the old list
+     */
+    SampleList subList(int fromIndex, int toIndex);
+
+    /**
+     * Binary search performed on timestamp array, the contract should be the same as
+     * {@link Collections#binarySearch(List, Object)} and {@link java.util.Arrays#binarySearch(int[], int)}
+     */
+    int binarySearch(long timestamp);
+
+    /**
+     * The implementation of this method should be as efficient as possible, and should avoid creating a new
+     * object per {@link Iterator#next()} call.
+     * <br>
+     * On the other hand, the caller of this method should NOT store/hold the {@link Sample} returned by previous
+     * {@link Iterator#next()} call, since there is no guarantee of immutability.
+     */
+    @Override
+    Iterator<Sample> iterator();
+
+    /**
+     * Get a java List of Samples from this list
+     * WARN: This method exists only for test-use, please refrain from using it in prod code unless you are
+     *       clear about the cost
+     */
+    List<Sample> toList();
+
+    /**
+     * Wrap a java List to {@link SampleList}, it's helpful when some stage need to create an instantiated sample,
+     * like {@link SumCountSample} and attach it to {@link org.opensearch.tsdb.query.aggregator.TimeSeries} or so
+     */
+    static SampleList fromList(List<Sample> samples) {
+        return new ListWrapper(samples);
+    }
+
+    final class ListWrapper implements SampleList {
+        private final List<Sample> inner;
+
+        private ListWrapper(List<Sample> inner) {
+            this.inner = inner;
+        }
+
+        @Override
+        public int size() {
+            return inner.size();
+        }
+
+        @Override
+        public double getValue(int index) {
+            return inner.get(index).getValue();
+        }
+
+        @Override
+        public long getTimestamp(int index) {
+            return inner.get(index).getTimestamp();
+        }
+
+        @Override
+        public Sample getSample(int index) {
+            return inner.get(index);
+        }
+
+        @Override
+        public SampleType getSampleType() {
+            if (isEmpty()) {
+                return SampleType.FLOAT_SAMPLE; // best guess if this list is empty
+            }
+            return inner.get(0).getSampleType();
+        }
+
+        @Override
+        public SampleList subList(int fromIndex, int toIndex) {
+            return new ListWrapper(inner.subList(fromIndex, toIndex));
+        }
+
+        @Override
+        public int binarySearch(long timestamp) {
+            return Collections.binarySearch(inner, new FloatSample(timestamp, 0), Comparator.comparingLong(Sample::getTimestamp));
+        }
+
+        @Override
+        public List<Sample> toList() {
+            return inner;
+        }
+
+        @Override
+        public Iterator<Sample> iterator() {
+            return inner.iterator();
+        }
+
+        @Override
+        public int hashCode() {
+            return inner.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof ListWrapper anotherWrapper) {
+                return inner.equals(anotherWrapper.inner);
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return inner.toString();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
@@ -12,6 +12,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.tsdb.core.model.ByteLabels;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesProvider;
 
@@ -197,7 +198,7 @@ public abstract class AbstractGroupingSampleStage extends AbstractGroupingStage 
     /**
      * Helper method to aggregate samples into an existing timestamp map.
      */
-    private void aggregateSamplesIntoMap(List<Sample> samples, Map<Long, Sample> timestampToSample) {
+    private void aggregateSamplesIntoMap(SampleList samples, Map<Long, Sample> timestampToSample) {
         for (Sample sample : samples) {
             // Skip NaN values - treat them as null/missing
             if (Double.isNaN(sample.getValue())) {

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractMapperStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractMapperStage.java
@@ -8,6 +8,7 @@
 package org.opensearch.tsdb.lang.m3.stage;
 
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
 
@@ -70,7 +71,7 @@ public abstract class AbstractMapperStage implements UnaryPipelineStage {
         List<TimeSeries> result = new ArrayList<>(input.size());
 
         for (TimeSeries series : input) {
-            List<Sample> originalSamples = series.getSamples();
+            SampleList originalSamples = series.getSamples();
             List<Sample> mappedSamples = new ArrayList<>(originalSamples.size());
 
             // Apply the mapping function to each sample

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/CountStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/CountStage.java
@@ -120,7 +120,7 @@ public class CountStage extends AbstractGroupingStage {
                 ByteLabels groupLabels = extractGroupLabelsDirect(series);
                 // groupLabels shouldn't be null from aggregation, but just be safe
                 if (groupLabels != null) {
-                    groupToCount.merge(groupLabels, series.getSamples().get(0).getValue(), Double::sum);
+                    groupToCount.merge(groupLabels, series.getSamples().getValue(0), Double::sum);
                 }
             }
         }

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/IntegralStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/IntegralStage.java
@@ -13,6 +13,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -72,7 +73,7 @@ public class IntegralStage implements UnaryPipelineStage {
         List<TimeSeries> result = new ArrayList<>(input.size());
 
         for (TimeSeries ts : input) {
-            List<Sample> samples = ts.getSamples();
+            SampleList samples = ts.getSamples();
             if (samples.isEmpty()) {
                 result.add(ts);
                 continue;

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/IsNonNullStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/IsNonNullStage.java
@@ -13,6 +13,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -123,13 +124,13 @@ public class IsNonNullStage implements UnaryPipelineStage {
         // This same pointer-based iteration pattern is used in TransformNullStage and could be shared
 
         // Build dense samples in one pass using a pointer into existing samples
-        List<Sample> existingSamples = series.getSamples();
+        SampleList existingSamples = series.getSamples();
         int sampleIndex = 0;
         long timestamp = minTimestamp;
 
         for (int i = 0; i < arraySize; i++) {
             // Check if current existing sample matches this timestamp
-            if (sampleIndex < existingSamples.size() && existingSamples.get(sampleIndex).getTimestamp() == timestamp) {
+            if (sampleIndex < existingSamples.size() && existingSamples.getTimestamp(sampleIndex) == timestamp) {
                 // Sample exists at this timestamp -> 1.0
                 denseSamples.add(new FloatSample(timestamp, 1.0));
                 sampleIndex++;

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/MovingStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/MovingStage.java
@@ -14,6 +14,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.lang.m3.common.WindowAggregationType;
 import org.opensearch.tsdb.lang.m3.stage.moving.AvgCircularBuffer;
 import org.opensearch.tsdb.lang.m3.stage.moving.MaxCircularBuffer;
@@ -68,7 +69,7 @@ public class MovingStage implements UnaryPipelineStage {
         List<TimeSeries> result = new ArrayList<>(input.size());
 
         for (TimeSeries ts : input) {
-            List<Sample> samples = ts.getSamples();
+            SampleList samples = ts.getSamples();
             if (samples.isEmpty()) {
                 result.add(ts);
                 continue;
@@ -107,9 +108,9 @@ public class MovingStage implements UnaryPipelineStage {
 
                 // Step 2: Update the window with the current data point
                 // Check if current timestamp matches the next sample in the input series
-                if (sampleIndex < samples.size() && samples.get(sampleIndex).getTimestamp() == timestamp) {
+                if (sampleIndex < samples.size() && samples.getTimestamp(sampleIndex) == timestamp) {
                     // Add actual value to window
-                    windowTransformer.add(samples.get(sampleIndex).getValue());
+                    windowTransformer.add(samples.getValue(sampleIndex));
                     sampleIndex++;
                 } else {
                     // Add null placeholder to window for missing data point

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/RemoveEmptyStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/RemoveEmptyStage.java
@@ -12,6 +12,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -44,13 +45,18 @@ public class RemoveEmptyStage implements UnaryPipelineStage {
             throw new NullPointerException(getName() + " stage received null input");
         }
         return input.stream().filter(series -> {
-            List<Sample> samples = series.getSamples();
+            SampleList samples = series.getSamples();
             // Remove if empty or if all values are NaN
             if (samples.isEmpty()) {
                 return false;
             }
             // Check if all values are NaN
-            return samples.stream().anyMatch(sample -> !Double.isNaN(sample.getValue()));
+            for (Sample sample : samples) {
+                if (!Double.isNaN(sample.getValue())) {
+                    return true;
+                }
+            }
+            return false;
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/ScaleToSecondsStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/ScaleToSecondsStage.java
@@ -13,6 +13,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -91,7 +92,7 @@ public class ScaleToSecondsStage implements UnaryPipelineStage {
             double scaleFactor = seconds / stepSeconds;
 
             // Process samples with the calculated scale factor
-            List<Sample> originalSamples = series.getSamples();
+            SampleList originalSamples = series.getSamples();
             List<Sample> mappedSamples = new ArrayList<>(originalSamples.size());
 
             for (Sample sample : originalSamples) {

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/SubtractStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/SubtractStage.java
@@ -13,6 +13,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 
@@ -94,7 +95,7 @@ public class SubtractStage extends AbstractBinaryProjectionStage {
         }
         Map<Long, Double> timestampToValue = new HashMap<>();
         for (TimeSeries timeSeries : rightTimeSeriesList) {
-            List<Sample> samples = timeSeries.getSamples();
+            SampleList samples = timeSeries.getSamples();
             for (Sample sample : samples) {
                 timestampToValue.merge(sample.getTimestamp(), sample.getValue(), Double::sum);
             }

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/SummarizeStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/SummarizeStage.java
@@ -12,6 +12,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.lang.m3.common.WindowAggregationType;
 import org.opensearch.tsdb.lang.m3.stage.summarize.AvgBucketSummarizer;
 import org.opensearch.tsdb.lang.m3.stage.summarize.BucketMapper;
@@ -178,7 +179,7 @@ public class SummarizeStage implements UnaryPipelineStage {
      * Process a single time series, summarizing its samples into buckets.
      */
     private TimeSeries processSeries(TimeSeries series) {
-        List<Sample> samples = series.getSamples();
+        SampleList samples = series.getSamples();
         if (samples.isEmpty()) {
             return series;
         }
@@ -221,8 +222,7 @@ public class SummarizeStage implements UnaryPipelineStage {
 
             // Accumulate all samples that fall within this bucket
             while (sampleIdx < samples.size()) {
-                Sample sample = samples.get(sampleIdx);
-                long sampleTimestamp = sample.getTimestamp();
+                long sampleTimestamp = samples.getTimestamp(sampleIdx);
 
                 if (sampleTimestamp >= currentBucketEnd) {
                     break; // This sample belongs to a future bucket
@@ -230,7 +230,7 @@ public class SummarizeStage implements UnaryPipelineStage {
 
                 if (sampleTimestamp >= currentBucketStart) {
                     // Only add if sample exists (null values are represented by absence)
-                    summarizer.accumulate(sample.getValue());
+                    summarizer.accumulate(samples.getValue(sampleIdx));
                 }
 
                 sampleIdx++;

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/SustainStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/SustainStage.java
@@ -13,6 +13,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -97,7 +98,7 @@ public class SustainStage implements UnaryPipelineStage {
      * @return a new time series with filtered samples
      */
     private TimeSeries filterSamples(TimeSeries series) {
-        List<Sample> samples = series.getSamples();
+        SampleList samples = series.getSamples();
 
         if (samples == null || samples.isEmpty()) {
             return series;

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/TransformNullStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/TransformNullStage.java
@@ -13,6 +13,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.stage.PipelineStageAnnotation;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -67,19 +68,19 @@ public class TransformNullStage implements UnaryPipelineStage {
             List<Sample> denseSamples = new ArrayList<>(arraySize);
 
             // Build dense samples in one pass using a pointer into existing samples
-            List<Sample> existingSamples = series.getSamples();
+            SampleList existingSamples = series.getSamples();
             int sampleIndex = 0;
             long timestamp = seriesMinTimestamp;
 
             for (int i = 0; i < arraySize; i++) {
                 // Check if current existing sample matches this timestamp
-                if (sampleIndex < existingSamples.size() && existingSamples.get(sampleIndex).getTimestamp() == timestamp) {
-                    double value = existingSamples.get(sampleIndex).getValue();
+                if (sampleIndex < existingSamples.size() && existingSamples.getTimestamp(sampleIndex) == timestamp) {
+                    double value = existingSamples.getValue(sampleIndex);
                     // Treat NaN as null/missing
                     if (Double.isNaN(value)) {
                         denseSamples.add(new FloatSample(timestamp, fillValue));
                     } else {
-                        denseSamples.add(existingSamples.get(sampleIndex));
+                        denseSamples.add(new FloatSample(existingSamples.getTimestamp(sampleIndex), existingSamples.getValue(sampleIndex)));
                     }
                     sampleIndex++;
                 } else {

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeries.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeries.java
@@ -14,6 +14,7 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.tsdb.core.model.ByteLabels;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.utils.SampleMerger;
 import org.opensearch.tsdb.query.stage.PipelineStageFactory;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
@@ -117,7 +118,7 @@ public class InternalTimeSeries extends InternalAggregation implements TimeSerie
         out.writeVInt(timeSeries.size());
         for (TimeSeries series : timeSeries) {
             out.writeInt(0); // hash - placeholder for now
-            List<Sample> samples = series.getSamples();
+            SampleList samples = series.getSamples();
             out.writeVInt(samples.size());
             for (Sample sample : samples) {
                 sample.writeTo(out);
@@ -204,7 +205,7 @@ public class InternalTimeSeries extends InternalAggregation implements TimeSerie
                 if (existingSeries != null) {
                     // Merge samples from same time series across segments using helper
                     // Use assumeSorted=true for reduce operations as samples should be sorted
-                    List<Sample> mergedSamples = MERGE_HELPER.merge(
+                    SampleList mergedSamples = MERGE_HELPER.merge(
                         existingSeries.getSamples(),
                         series.getSamples(),
                         true // assumeSorted - samples should be sorted in reduce phase

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeries.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeries.java
@@ -9,6 +9,7 @@ package org.opensearch.tsdb.query.aggregator;
 
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -92,7 +93,7 @@ public class TimeSeries {
      */
     public static final long ESTIMATED_SAMPLE_SIZE = 16;
 
-    private final List<Sample> samples;
+    private final SampleList samples;
     private final Labels labels; // Store all labels and their values
     private String alias; // Optional alias name for renamed series
 
@@ -116,6 +117,18 @@ public class TimeSeries {
      * Clients should fill with null samples if dense representation is required.</p>
      */
     public TimeSeries(List<Sample> samples, Labels labels, long minTimestamp, long maxTimestamp, long step, String alias) {
+        this.samples = SampleList.fromList(samples);
+        this.labels = labels;
+        this.minTimestamp = minTimestamp;
+        this.maxTimestamp = maxTimestamp;
+        this.step = step;
+        this.alias = alias;
+    }
+
+    /**
+     * Similar to {@link #TimeSeries(List, Labels, long, long, long, String)}
+     */
+    public TimeSeries(SampleList samples, Labels labels, long minTimestamp, long maxTimestamp, long step, String alias) {
         this.samples = samples;
         this.labels = labels;
         this.minTimestamp = minTimestamp;
@@ -129,7 +142,7 @@ public class TimeSeries {
      *
      * @return List of time series samples
      */
-    public List<Sample> getSamples() {
+    public SampleList getSamples() {
         return samples;
     }
 

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
@@ -29,6 +29,7 @@ import org.opensearch.tsdb.core.model.ByteLabels;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.core.reader.TSDBDocValues;
 import org.opensearch.tsdb.core.reader.TSDBLeafReader;
 import org.opensearch.tsdb.metrics.TSDBMetrics;
@@ -483,9 +484,9 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
             if (existingSeries != null) {
                 // Merge samples from same time series using helper
                 // Assume data points within each chunk are sorted by timestamp
-                List<Sample> mergedSamples = MERGE_HELPER.merge(
+                SampleList mergedSamples = MERGE_HELPER.merge(
                     existingSeries.getSamples(),
-                    alignedSamples,
+                    SampleList.fromList(alignedSamples),
                     true // assumeSorted - data points within each chunk are sorted
                 );
 

--- a/src/main/java/org/opensearch/tsdb/query/utils/TimeSeriesOutputMapper.java
+++ b/src/main/java/org/opensearch/tsdb/query/utils/TimeSeriesOutputMapper.java
@@ -10,6 +10,7 @@ package org.opensearch.tsdb.query.utils;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.aggregator.InternalTimeSeries;
 
@@ -136,7 +137,7 @@ public class TimeSeriesOutputMapper {
      * @param samples List of samples to transform
      * @return List of [timestamp, value] pairs
      */
-    public static List<List<Object>> transformSamplesToValues(List<Sample> samples) {
+    public static List<List<Object>> transformSamplesToValues(SampleList samples) {
         List<List<Object>> values = samples != null ? new ArrayList<>(samples.size()) : new ArrayList<>();
         if (samples != null) {
             for (Sample sample : samples) {

--- a/src/test/java/org/opensearch/index/engine/TSDBEngineSingleNodeTests.java
+++ b/src/test/java/org/opensearch/index/engine/TSDBEngineSingleNodeTests.java
@@ -238,7 +238,7 @@ public class TSDBEngineSingleNodeTests extends OpenSearchSingleNodeTestCase {
 
             String serverValue = labels.get("server");
             String regionValue = labels.get("region");
-            List<Sample> actualSamples = series.getSamples();
+            List<Sample> actualSamples = series.getSamples().toList();
             assertNotNull("Samples should not be null", actualSamples);
 
             // Build expected samples and compare

--- a/src/test/java/org/opensearch/tsdb/TSAggregationPluginTests.java
+++ b/src/test/java/org/opensearch/tsdb/TSAggregationPluginTests.java
@@ -95,7 +95,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             assertSamplesEqual(
                 "Scaled samples should match expected values",
                 expectedSamples,
-                series.getSamples(),
+                series.getSamples().toList(),
                 SAMPLE_COMPARISON_DELTA
             );
         });
@@ -138,7 +138,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             assertSamplesEqual(
                 "Summed samples should match expected values (NaN should be skipped)",
                 expectedSamples,
-                aggregatedSeries.getSamples(),
+                aggregatedSeries.getSamples().toList(),
                 SAMPLE_COMPARISON_DELTA
             );
         });
@@ -179,7 +179,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             assertSamplesEqual(
                 "Scaled then summed samples should match expected values",
                 expectedSamples,
-                series.getSamples(),
+                series.getSamples().toList(),
                 SAMPLE_COMPARISON_DELTA
             );
         });
@@ -279,7 +279,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             assertFalse("Time series list should not be empty", timeSeries.isEmpty());
 
             TimeSeries series = timeSeries.get(0);
-            List<Sample> samples = series.getSamples();
+            List<Sample> samples = series.getSamples().toList();
 
             // After deduplication with [1100, 1300) range (inclusive start, exclusive end):
             // - 1000 is filtered out (before minTimestamp)
@@ -409,7 +409,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             assertEquals("Should have exactly 1 merged time series", 1, seriesList.size());
 
             TimeSeries series = seriesList.get(0);
-            List<Sample> samples = series.getSamples();
+            List<Sample> samples = series.getSamples().toList();
 
             // Verify all 4 samples are present and merged correctly
             List<Sample> expectedSamples = List.of(
@@ -663,7 +663,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
 
             // Verify the scaling actually happened by checking some sample values
             if (!scaledSeries.getSamples().isEmpty()) {
-                double firstScaledValue = scaledSeries.getSamples().get(0).getValue();
+                double firstScaledValue = scaledSeries.getSamples().getValue(0);
                 // Should be approximately 10.0 * 2.0 = 20.0 (depending on stage implementation)
                 assertTrue("First scaled value should be positive", firstScaledValue > 0);
             }
@@ -705,7 +705,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             TimeSeries server1Memory = server1Series.get(0);
             assertFalse("Server1 Memory should have samples", server1Memory.getSamples().isEmpty());
 
-            List<Sample> server1Samples = server1Memory.getSamples();
+            List<Sample> server1Samples = server1Memory.getSamples().toList();
 
             // Verify transformation: 2048 MB * 1024 = 2097152 KB
             List<Sample> expectedServer1Samples = List.of(
@@ -727,7 +727,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
 
             TimeSeries server2Memory = server2Series.get(0);
 
-            List<Sample> server2Samples = server2Memory.getSamples();
+            List<Sample> server2Samples = server2Memory.getSamples().toList();
 
             // Verify transformation: 1024 MB * 1024 = 1048576 KB
             List<Sample> expectedServer2Samples = List.of(
@@ -826,7 +826,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
 
             // Verify the nested unfold processed data correctly (scaled by 2.0)
             TimeSeries nestedSeries = unfoldNested.getTimeSeries().get(0);
-            List<Sample> nestedSamples = nestedSeries.getSamples();
+            List<Sample> nestedSamples = nestedSeries.getSamples().toList();
             List<Sample> expectedNestedSamples = List.of(
                 new FloatSample(1000L, 20.0f),
                 new FloatSample(2000L, 40.0f),
@@ -847,7 +847,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             // Verify the coordinator processed the nested unfold data correctly
             // Unfold scaled by 2.0, then coordinator scaled by 0.5: 10*2*0.5=10, 20*2*0.5=20, 30*2*0.5=30
             TimeSeries coordinatorSeries = coordinatorResult.getTimeSeries().get(0);
-            List<Sample> coordinatorSamples = coordinatorSeries.getSamples();
+            List<Sample> coordinatorSamples = coordinatorSeries.getSamples().toList();
             List<Sample> expectedCoordinatorSamples = List.of(
                 new FloatSample(1000L, 10.0f),
                 new FloatSample(2000L, 20.0f),
@@ -1531,7 +1531,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             // t=2000: [100,200,300,400] -> fractionalRank=0.0*4=0.0, ceil=0, <=1 -> 100
             // t=3000: [15,25,35] -> fractionalRank=0.0*3=0.0, ceil=0, <=1 -> 15
             List<Sample> expectedP0 = List.of(new FloatSample(1000L, 10.0f), new FloatSample(2000L, 100.0f), new FloatSample(3000L, 15.0f));
-            assertSamplesEqual("0th percentile (minimum)", expectedP0, p0Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("0th percentile (minimum)", expectedP0, p0Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
 
             // Verify 30th percentile
             // t=1000: [10,20,30,40,50] -> fractionalRank=0.3*5=1.5, ceil=2, index=1 -> 20
@@ -1542,7 +1542,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
                 new FloatSample(2000L, 200.0f),
                 new FloatSample(3000L, 15.0f)
             );
-            assertSamplesEqual("30th percentile", expectedP30, p30Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("30th percentile", expectedP30, p30Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
 
             // Verify 50th percentile (median)
             // t=1000: [10,20,30,40,50] -> fractionalRank=0.5*5=2.5, ceil=3, index=2 -> 30
@@ -1553,7 +1553,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
                 new FloatSample(2000L, 200.0f),
                 new FloatSample(3000L, 25.0f)
             );
-            assertSamplesEqual("50th percentile (median)", expectedP50, p50Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("50th percentile (median)", expectedP50, p50Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
 
             // Verify 90th percentile
             // t=1000: [10,20,30,40,50] -> fractionalRank=0.9*5=4.5, ceil=5, index=4 -> 50
@@ -1564,7 +1564,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
                 new FloatSample(2000L, 400.0f),
                 new FloatSample(3000L, 35.0f)
             );
-            assertSamplesEqual("90th percentile", expectedP90, p90Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("90th percentile", expectedP90, p90Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
 
             // Verify 95th percentile
             // t=1000: [10,20,30,40,50] -> fractionalRank=0.95*5=4.75, ceil=5, index=4 -> 50
@@ -1575,7 +1575,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
                 new FloatSample(2000L, 400.0f),
                 new FloatSample(3000L, 35.0f)
             );
-            assertSamplesEqual("95th percentile", expectedP95, p95Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("95th percentile", expectedP95, p95Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
 
             // Verify 99th percentile
             // t=1000: [10,20,30,40,50] -> fractionalRank=0.99*5=4.95, ceil=5, index=4 -> 50
@@ -1586,7 +1586,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
                 new FloatSample(2000L, 400.0f),
                 new FloatSample(3000L, 35.0f)
             );
-            assertSamplesEqual("99th percentile", expectedP99, p99Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("99th percentile", expectedP99, p99Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
 
             // Verify 100th percentile (maximum)
             // t=1000: [10,20,30,40,50] -> fractionalRank=1.0*5=5.0, ceil=5, index=4 -> 50
@@ -1597,7 +1597,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
                 new FloatSample(2000L, 400.0f),
                 new FloatSample(3000L, 35.0f)
             );
-            assertSamplesEqual("100th percentile (maximum)", expectedP100, p100Series.getSamples(), SAMPLE_COMPARISON_DELTA);
+            assertSamplesEqual("100th percentile (maximum)", expectedP100, p100Series.getSamples().toList(), SAMPLE_COMPARISON_DELTA);
         });
     }
 
@@ -1635,7 +1635,7 @@ public class TSAggregationPluginTests extends TimeSeriesAggregatorTestCase {
             assertEquals("Should have exactly 1 time series", 1, timeSeries.size());
 
             TimeSeries series = timeSeries.getFirst();
-            List<Sample> samples = series.getSamples();
+            List<Sample> samples = series.getSamples().toList();
 
             // Verify samples are scaled by 2.0
             List<Sample> expectedSamples = List.of(

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbsStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbsStageTests.java
@@ -60,14 +60,14 @@ public class AbsStageTests extends AbstractWireSerializingTestCase<AbsStage> {
         assertEquals(1, result.size());
         TimeSeries absTimeSeries = result.getFirst();
         assertEquals(8, absTimeSeries.getSamples().size());
-        assertEquals(1.5, absTimeSeries.getSamples().get(0).getValue(), 0.0);
-        assertEquals(2.3, absTimeSeries.getSamples().get(1).getValue(), 0.0);
-        assertEquals(Double.NaN, absTimeSeries.getSamples().get(2).getValue(), 0.0);
-        assertEquals(Double.POSITIVE_INFINITY, absTimeSeries.getSamples().get(3).getValue(), 0.0);
-        assertEquals(Double.POSITIVE_INFINITY, absTimeSeries.getSamples().get(4).getValue(), 0.0);
-        assertEquals(Double.MIN_VALUE, absTimeSeries.getSamples().get(5).getValue(), 0.0);
-        assertEquals(Double.MAX_VALUE, absTimeSeries.getSamples().get(6).getValue(), 0.0);
-        assertEquals(0.0, absTimeSeries.getSamples().get(7).getValue(), 0.0);
+        assertEquals(1.5, absTimeSeries.getSamples().getValue(0), 0.0);
+        assertEquals(2.3, absTimeSeries.getSamples().getValue(1), 0.0);
+        assertEquals(Double.NaN, absTimeSeries.getSamples().getValue(2), 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, absTimeSeries.getSamples().getValue(3), 0.0);
+        assertEquals(Double.POSITIVE_INFINITY, absTimeSeries.getSamples().getValue(4), 0.0);
+        assertEquals(Double.MIN_VALUE, absTimeSeries.getSamples().getValue(5), 0.0);
+        assertEquals(Double.MAX_VALUE, absTimeSeries.getSamples().getValue(6), 0.0);
+        assertEquals(0.0, absTimeSeries.getSamples().getValue(7), 0.0);
     }
 
     public void testProcessWithEmptyInput() {
@@ -130,11 +130,7 @@ public class AbsStageTests extends AbstractWireSerializingTestCase<AbsStage> {
         List<TimeSeries> secondAbs = absStage.process(firstAbs);
 
         // Results should be identical
-        assertEquals(
-            firstAbs.getFirst().getSamples().getFirst().getValue(),
-            secondAbs.getFirst().getSamples().getFirst().getValue(),
-            0.000
-        );
+        assertEquals(firstAbs.getFirst().getSamples().getValue(0), secondAbs.getFirst().getSamples().getValue(0), 0.000);
     }
 
     public void testNonNegativeOutput() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbstractMapperStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbstractMapperStageTests.java
@@ -74,7 +74,7 @@ public class AbstractMapperStageTests extends OpenSearchTestCase {
         assertEquals(1, result.size());
         TimeSeries resultSeries = result.get(0);
         assertEquals(1, resultSeries.getSamples().size()); // Only sample with value 10.0 remains
-        assertEquals(10.0, resultSeries.getSamples().get(0).getValue(), 0.001);
+        assertEquals(10.0, resultSeries.getSamples().getValue(0), 0.001);
 
         // Assert - metadata should be preserved by default implementation
         assertEquals(labels, resultSeries.getLabels());

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AliasStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AliasStageTests.java
@@ -44,7 +44,7 @@ public class AliasStageTests extends AbstractWireSerializingTestCase<AliasStage>
 
         assertEquals(1, result.size());
         assertEquals("new_series_name", result.getFirst().getAlias());
-        assertEquals(samples, result.getFirst().getSamples());
+        assertEquals(samples, result.getFirst().getSamples().toList());
         assertEquals(labels, result.getFirst().getLabels());
     }
 
@@ -64,7 +64,7 @@ public class AliasStageTests extends AbstractWireSerializingTestCase<AliasStage>
 
         assertEquals(1, result.size());
         assertEquals("server_web01_job_nginx", result.getFirst().getAlias());
-        assertEquals(samples, result.getFirst().getSamples());
+        assertEquals(samples, result.getFirst().getSamples().toList());
         assertEquals(labels, result.getFirst().getLabels());
     }
 
@@ -254,8 +254,8 @@ public class AliasStageTests extends AbstractWireSerializingTestCase<AliasStage>
         // Verify original data is preserved
         assertEquals(labels1, result.get(0).getLabels());
         assertEquals(labels2, result.get(1).getLabels());
-        assertEquals(samples1, result.get(0).getSamples());
-        assertEquals(samples2, result.get(1).getSamples());
+        assertEquals(samples1, result.get(0).getSamples().toList());
+        assertEquals(samples2, result.get(1).getSamples().toList());
     }
 
     /**
@@ -281,7 +281,7 @@ public class AliasStageTests extends AbstractWireSerializingTestCase<AliasStage>
 
         // Check original data is preserved
         assertEquals(originalTs.getLabels(), resultTs.getLabels());
-        assertEquals(originalTs.getSamples(), resultTs.getSamples());
+        assertEquals(originalTs.getSamples().toList(), resultTs.getSamples().toList());
         assertEquals(originalTs.getMinTimestamp(), resultTs.getMinTimestamp());
         assertEquals(originalTs.getMaxTimestamp(), resultTs.getMaxTimestamp());
         assertEquals(originalTs.getStep(), resultTs.getStep());

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AsPercentStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AsPercentStageTests.java
@@ -65,7 +65,7 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
         // Should only include matching timestamps: 1000L, 2000L
         assertEquals(2, resultSeries.getSamples().size());
 
-        List<Sample> samples = resultSeries.getSamples();
+        List<Sample> samples = resultSeries.getSamples().toList();
 
         // 1000L: 10.0/100.0 * 100 = 10.0%
         assertEquals(1000L, samples.get(0).getTimestamp());
@@ -127,7 +127,7 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
             new FloatSample(2500L, 30.0),
             new FloatSample(4500L, 22.22)
         );
-        assertSamplesEqual("Multiple right series with normalization", expectedSamples, resultSeries.getSamples(), 0.01);
+        assertSamplesEqual("Multiple right series with normalization", expectedSamples, resultSeries.getSamples().toList(), 0.01);
 
         // Verify that result has the original labels plus the type:ratios label
         assertEquals("ratios", resultSeries.getLabels().get("type"));
@@ -180,7 +180,7 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
             new FloatSample(20000L, 17.5f),
             new FloatSample(40000L, 16.67f)
         );
-        assertSamplesEqual("Misaligned step sizes and start times", expectedSamples, resultSeries.getSamples(), 0.01);
+        assertSamplesEqual("Misaligned step sizes and start times", expectedSamples, resultSeries.getSamples().toList(), 0.01);
 
         // Verify the normalized step size is LCM(10000, 20000) = 20000
         assertEquals(20000L, resultSeries.getStep());
@@ -226,8 +226,8 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
         List<TimeSeries> result = stage.process(Arrays.asList(leftSeries), Arrays.asList(rightSeries));
         assertEquals("Zero right values should return series with NaN", 1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertTrue("Should be NaN when right value is zero", Double.isNaN(result.get(0).getSamples().get(0).getValue()));
-        assertEquals(1000L, result.get(0).getSamples().get(0).getTimestamp());
+        assertTrue("Should be NaN when right value is zero", Double.isNaN(result.get(0).getSamples().getValue(0)));
+        assertEquals(1000L, result.get(0).getSamples().getTimestamp(0));
 
         // Test with empty inputs
         result = stage.process(new ArrayList<>(), Arrays.asList(rightSeries));
@@ -265,8 +265,8 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
         assertEquals(1, result.size());
         TimeSeries resultSeries = result.get(0);
         assertEquals(1, resultSeries.getSamples().size());
-        assertEquals(25.0, resultSeries.getSamples().get(0).getValue(), 0.001); // 25.0/100.0 * 100 = 25.0%
-        assertEquals(1000L, resultSeries.getSamples().get(0).getTimestamp());
+        assertEquals(25.0, resultSeries.getSamples().getValue(0), 0.001); // 25.0/100.0 * 100 = 25.0%
+        assertEquals(1000L, resultSeries.getSamples().getTimestamp(0));
     }
 
     public void testSelectiveLabelMatchingWithMultipleKeys() {
@@ -297,8 +297,8 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
         assertEquals(1, result.size());
         TimeSeries resultSeries = result.get(0);
         assertEquals(1, resultSeries.getSamples().size());
-        assertEquals(25.0, resultSeries.getSamples().get(0).getValue(), 0.001); // 50.0/200.0 * 100 = 25.0%
-        assertEquals(1000L, resultSeries.getSamples().get(0).getTimestamp());
+        assertEquals(25.0, resultSeries.getSamples().getValue(0), 0.001); // 50.0/200.0 * 100 = 25.0%
+        assertEquals(1000L, resultSeries.getSamples().getTimestamp(0));
     }
 
     public void testSelectiveLabelMatchingWithMultipleKeysException() {
@@ -397,12 +397,12 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
         assertEquals("Should process all series since labels are ignored if it is a single right series", 2, result.size());
         TimeSeries resultSeries = result.get(0);
         assertEquals(1, resultSeries.getSamples().size());
-        assertEquals(25.0, resultSeries.getSamples().get(0).getValue(), 0.001); // 25.0/100.0 * 100 = 25.0%
-        assertEquals(1000L, resultSeries.getSamples().get(0).getTimestamp());
+        assertEquals(25.0, resultSeries.getSamples().getValue(0), 0.001); // 25.0/100.0 * 100 = 25.0%
+        assertEquals(1000L, resultSeries.getSamples().getTimestamp(0));
         resultSeries = result.get(1);
         assertEquals(1, resultSeries.getSamples().size());
-        assertEquals(50.0, resultSeries.getSamples().get(0).getValue(), 0.001); // 25.0/100.0 * 100 = 25.0%
-        assertEquals(1000L, resultSeries.getSamples().get(0).getTimestamp());
+        assertEquals(50.0, resultSeries.getSamples().getValue(0), 0.001); // 25.0/100.0 * 100 = 25.0%
+        assertEquals(1000L, resultSeries.getSamples().getTimestamp(0));
     }
 
     public void testEdgeCases() {
@@ -550,7 +550,7 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
             new FloatSample(1000L, 20.0),  // 20.0/100.0 * 100 = 20.0%
             new FloatSample(2000L, 20.0)   // 40.0/200.0 * 100 = 20.0%
         );
-        assertSamplesEqual("ClusterA samples", expectedSamplesA, resultClusterA.getSamples(), 0.001);
+        assertSamplesEqual("ClusterA samples", expectedSamplesA, resultClusterA.getSamples().toList(), 0.001);
         assertEquals("ratios", resultClusterA.getLabels().get("type"));
         assertEquals("clusterA", resultClusterA.getLabels().get("cluster"));
         assertEquals("api", resultClusterA.getLabels().get("service"));
@@ -562,7 +562,7 @@ public class AsPercentStageTests extends AbstractWireSerializingTestCase<AsPerce
             new FloatSample(1000L, 20.0),  // 30.0/150.0 * 100 = 20.0%
             new FloatSample(2000L, 20.0)   // 60.0/300.0 * 100 = 20.0%
         );
-        assertSamplesEqual("ClusterB samples", expectedSamplesB, resultClusterB.getSamples(), 0.001);
+        assertSamplesEqual("ClusterB samples", expectedSamplesB, resultClusterB.getSamples().toList(), 0.001);
         assertEquals("ratios", resultClusterB.getLabels().get("type"));
         assertEquals("clusterB", resultClusterB.getLabels().get("cluster"));
         assertEquals("api", resultClusterB.getLabels().get("service"));

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AvgStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AvgStageTests.java
@@ -53,7 +53,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
                 new FloatSample(2000L, 16.6), // (20+40+15+6+2)/5 = 83/5 = 16.6
                 new FloatSample(3000L, 25.4)  // (30+60+25+9+3)/5 = 127/5 = 25.4
             ),
-            averaged.getSamples()
+            averaged.getSamples().toList()
         );
     }
 
@@ -74,7 +74,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
                 new FloatSample(2000L, 30.0), // (20 + 40) / 2 = 60 / 2 = 30.0
                 new FloatSample(3000L, 45.0)  // (30 + 60) / 2 = 90 / 2 = 45.0
             ),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // Find the service1 group (ts3) - single series materialized to FloatSample
@@ -83,7 +83,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
         assertEquals(3, service1Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // Find the service2 group (ts4) - single series materialized to FloatSample
@@ -92,7 +92,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
         assertEquals(3, service2Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -114,7 +114,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
         // Values should be averaged across aggregations (materialized to FloatSample during final reduce)
         assertEquals(
             List.of(new FloatSample(1000L, 7.8), new FloatSample(2000L, 16.6), new FloatSample(3000L, 25.4)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -136,7 +136,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
         // Values should remain as SumCountSample during intermediate reduce (no materialization)
         assertEquals(
             List.of(new SumCountSample(1000L, 39.0, 5), new SumCountSample(2000L, 83.0, 5), new SumCountSample(3000L, 127.0, 5)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -174,7 +174,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
                 new FloatSample(2000L, 40.0),  // 40 / 1 (NaN skipped, not counted)
                 new FloatSample(3000L, 30.0)   // 30 / 1 (NaN skipped, not counted)
             ),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -225,7 +225,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
                 new FloatSample(20000L, 20.0),  // 20s: only ts1, avg = 20.0/1 = 20.0
                 new FloatSample(30000L, 40.0)   // 30s: only ts2, avg = 40.0/1 = 40.0
             ),
-            averaged.getSamples()
+            averaged.getSamples().toList()
         );
     }
 
@@ -250,7 +250,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
                 new FloatSample(20000L, 15.0),  // 20s: only ts1, avg = 15.0/1 = 15.0
                 new FloatSample(30000L, 35.0)   // 30s: only ts2, avg = 35.0/1 = 35.0
             ),
-            averaged.getSamples()
+            averaged.getSamples().toList()
         );
     }
 
@@ -287,7 +287,7 @@ public class AvgStageTests extends AbstractWireSerializingTestCase<AvgStage> {
                 new SumCountSample(2000L, 83.0, 5), // (20+40+15+6+2) = 83, count = 5
                 new SumCountSample(3000L, 127.0, 5) // (30+60+25+9+3) = 127, count = 5
             ),
-            averaged.getSamples()
+            averaged.getSamples().toList()
         );
     }
 

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/BinaryFallbackSeriesStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/BinaryFallbackSeriesStageTests.java
@@ -48,7 +48,7 @@ public class BinaryFallbackSeriesStageTests extends AbstractWireSerializingTestC
 
         assertEquals(1, result.size());
         assertEquals("left", result.get(0).getLabels().get("name"));
-        assertSamplesEqual("Left series samples should match", leftSamples, result.get(0).getSamples());
+        assertSamplesEqual("Left series samples should match", leftSamples, result.get(0).getSamples().toList());
     }
 
     /**
@@ -66,7 +66,7 @@ public class BinaryFallbackSeriesStageTests extends AbstractWireSerializingTestC
 
         assertEquals(1, result.size());
         assertEquals("fallback", result.get(0).getLabels().get("name"));
-        assertSamplesEqual("Right series samples should match", rightSamples, result.get(0).getSamples());
+        assertSamplesEqual("Right series samples should match", rightSamples, result.get(0).getSamples().toList());
     }
 
     /**

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/CountStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/CountStageTests.java
@@ -278,7 +278,7 @@ public class CountStageTests extends AbstractWireSerializingTestCase<CountStage>
         assertNotNull(actualTimeSeries);
         assertEquals(expectedTimestampCount, actualTimeSeries.getSamples().size());
         // Use allMatch() on a Stream
-        boolean allEqual = actualTimeSeries.getSamples().stream().allMatch(s -> s.getValue() == expectedCount);
+        boolean allEqual = actualTimeSeries.getSamples().toList().stream().allMatch(s -> s.getValue() == expectedCount);
         assertTrue("All value in the time series must be equal to " + expectedCount, allEqual);
     }
 }

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/DerivativeStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/DerivativeStageTests.java
@@ -53,7 +53,7 @@ public class DerivativeStageTests extends AbstractWireSerializingTestCase<Deriva
             new FloatSample(3000L, -10.0), // 20 - 30
             new FloatSample(4000L, 30.0) // 50 - 20
         );
-        assertSamplesEqual("Basic derivative", expectedSamples, result.get(0).getSamples());
+        assertSamplesEqual("Basic derivative", expectedSamples, result.get(0).getSamples().toList());
     }
 
     public void testProcessWithNaNValues() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/DivideStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/DivideStageTests.java
@@ -60,7 +60,7 @@ public class DivideStageTests extends AbstractWireSerializingTestCase<DivideStag
         // Left series has NaN at 3000L, so that timestamp is skipped after normalization
         assertEquals(2, resultSeries.getSamples().size());
 
-        List<Sample> samples = resultSeries.getSamples();
+        List<Sample> samples = resultSeries.getSamples().toList();
 
         // 1000L: 100.0/10.0 = 10.0
         assertEquals(1000L, samples.get(0).getTimestamp());
@@ -113,7 +113,7 @@ public class DivideStageTests extends AbstractWireSerializingTestCase<DivideStag
         assertEquals("api", resultSeries.getLabels().get("service"));
         assertEquals("server1", resultSeries.getLabels().get("instance"));
 
-        List<Sample> samples = resultSeries.getSamples();
+        List<Sample> samples = resultSeries.getSamples().toList();
 
         // 1000L: 500.0/100.0 = 5.0
         assertEquals(1000L, samples.get(0).getTimestamp());
@@ -148,7 +148,7 @@ public class DivideStageTests extends AbstractWireSerializingTestCase<DivideStag
 
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertEquals(5.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(5.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testSingleRightSeriesWithLabelMatching() {
@@ -171,8 +171,8 @@ public class DivideStageTests extends AbstractWireSerializingTestCase<DivideStag
         List<TimeSeries> result = stage.process(Arrays.asList(leftSeries1, leftSeries2), Arrays.asList(rightSeries));
 
         assertEquals(2, result.size());
-        assertEquals(5.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(10.0, result.get(1).getSamples().get(0).getValue(), 0.001);
+        assertEquals(5.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(10.0, result.get(1).getSamples().getValue(0), 0.001);
     }
 
     public void testSelectiveLabelMatchingWithMultipleKeysException() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/IntegralStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/IntegralStageTests.java
@@ -60,7 +60,7 @@ public class IntegralStageTests extends AbstractWireSerializingTestCase<Integral
             new FloatSample(4000L, 3.0), // Reset to 0, then 3
             new FloatSample(5000L, 7.0)
         );
-        assertSamplesEqual("ResetOnNull true", expectedSamples, result.get(0).getSamples());
+        assertSamplesEqual("ResetOnNull true", expectedSamples, result.get(0).getSamples().toList());
     }
 
     public void testProcessWithResetOnNullFalse() {
@@ -83,7 +83,7 @@ public class IntegralStageTests extends AbstractWireSerializingTestCase<Integral
             new FloatSample(4000L, 6.0), // Continues: 3 + 3
             new FloatSample(5000L, 10.0)
         );
-        assertSamplesEqual("ResetOnNull false", expectedSamples, result.get(0).getSamples());
+        assertSamplesEqual("ResetOnNull false", expectedSamples, result.get(0).getSamples().toList());
     }
 
     public void testProcessWithAllNaN() {
@@ -114,7 +114,7 @@ public class IntegralStageTests extends AbstractWireSerializingTestCase<Integral
             new FloatSample(2000L, 3.0),
             new FloatSample(5000L, 3.0) // Reset due to gap, then 3
         );
-        assertSamplesEqual("Gap test", expectedSamples, result.get(0).getSamples());
+        assertSamplesEqual("Gap test", expectedSamples, result.get(0).getSamples().toList());
     }
 
     public void testDefaultConstructor() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/IsNonNullStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/IsNonNullStageTests.java
@@ -69,7 +69,7 @@ public class IsNonNullStageTests extends AbstractWireSerializingTestCase<IsNonNu
             new FloatSample(3000L, 1.0),  // present
             new FloatSample(4000L, 1.0)   // present
         );
-        assertSamplesEqual("IsNonNull Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("IsNonNull Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: mix of present and missing
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -79,7 +79,7 @@ public class IsNonNullStageTests extends AbstractWireSerializingTestCase<IsNonNu
             new FloatSample(3000L, 1.0),  // present
             new FloatSample(4000L, 0.0)   // missing
         );
-        assertSamplesEqual("IsNonNull Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("IsNonNull Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result: all timestamps missing -> all 0.0
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");
@@ -89,7 +89,7 @@ public class IsNonNullStageTests extends AbstractWireSerializingTestCase<IsNonNu
             new FloatSample(3000L, 0.0),  // missing
             new FloatSample(4000L, 0.0)   // missing
         );
-        assertSamplesEqual("IsNonNull Empty", expectedEmpty, emptyResult.getSamples());
+        assertSamplesEqual("IsNonNull Empty", expectedEmpty, emptyResult.getSamples().toList());
     }
 
     /**
@@ -125,7 +125,7 @@ public class IsNonNullStageTests extends AbstractWireSerializingTestCase<IsNonNu
             new FloatSample(5000L, 1.0),  // MIN present
             new FloatSample(6000L, 1.0)   // MAX present
         );
-        assertSamplesEqual("IsNonNull Special Values", expected, result.get(0).getSamples());
+        assertSamplesEqual("IsNonNull Special Values", expected, result.get(0).getSamples().toList());
     }
 
     /**

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/KeepLastValueStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/KeepLastValueStageTests.java
@@ -75,7 +75,7 @@ public class KeepLastValueStageTests extends AbstractWireSerializingTestCase<Kee
         );
 
         // Verify: Should fill missing values with last non-null value
-        TestUtils.assertSamplesEqual("Filled samples do not match expected", expectedSamples, result.getFirst().getSamples());
+        TestUtils.assertSamplesEqual("Filled samples do not match expected", expectedSamples, result.getFirst().getSamples().toList());
     }
 
     /**
@@ -114,7 +114,7 @@ public class KeepLastValueStageTests extends AbstractWireSerializingTestCase<Kee
         );
 
         // Verify: Should fill missing values with last non-null value within interval
-        TestUtils.assertSamplesEqual("Filled samples do not match expected", expectedSamples, result.getFirst().getSamples());
+        TestUtils.assertSamplesEqual("Filled samples do not match expected", expectedSamples, result.getFirst().getSamples().toList());
     }
 
     /**
@@ -144,7 +144,7 @@ public class KeepLastValueStageTests extends AbstractWireSerializingTestCase<Kee
             // 1200 missing - can't fill
             new FloatSample(1300L, 40.0)
         );
-        TestUtils.assertSamplesEqual("Filled samples do not match expected", expectedSamples, result.getFirst().getSamples());
+        TestUtils.assertSamplesEqual("Filled samples do not match expected", expectedSamples, result.getFirst().getSamples().toList());
     }
 
     /**
@@ -168,8 +168,8 @@ public class KeepLastValueStageTests extends AbstractWireSerializingTestCase<Kee
 
         // Verify: Should return unchanged data
         assertEquals(1, result.size());
-        List<Sample> outputSamples = result.getFirst().getSamples();
-        TestUtils.assertSamplesEqual("Filled samples do not match expected", inputSeries.getSamples(), outputSamples);
+        List<Sample> outputSamples = result.getFirst().getSamples().toList();
+        TestUtils.assertSamplesEqual("Filled samples do not match expected", inputSeries.getSamples().toList(), outputSamples);
     }
 
     /**
@@ -196,7 +196,7 @@ public class KeepLastValueStageTests extends AbstractWireSerializingTestCase<Kee
 
         // Verify: Should return empty (can't fill without any reference values)
         assertEquals(1, result.size());
-        List<Sample> outputSamples = result.get(0).getSamples();
+        List<Sample> outputSamples = result.get(0).getSamples().toList();
         assertEquals(0, outputSamples.size());
     }
 

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/MaxStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/MaxStageTests.java
@@ -48,7 +48,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
                 new FloatSample(2000L, 40.0), // max(20, 40, 15, 6, 2) = 40
                 new FloatSample(3000L, 60.0)  // max(30, 60, 25, 9, 3) = 60
             ),
-            maxed.getSamples()
+            maxed.getSamples().toList()
         );
     }
 
@@ -69,7 +69,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
                 new FloatSample(2000L, 40.0), // max(20, 40) = 40
                 new FloatSample(3000L, 60.0)  // max(30, 60) = 60
             ),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // Find the service1 group (ts3) - unchanged since single series
@@ -78,7 +78,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
         assertEquals(3, service1Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // Find the service2 group (ts4) - unchanged since single series
@@ -87,7 +87,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
         assertEquals(3, service2Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -109,7 +109,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
         // Values should be maximum across aggregations
         assertEquals(
             List.of(new FloatSample(1000L, 20.0), new FloatSample(2000L, 40.0), new FloatSample(3000L, 60.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -131,7 +131,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
         // Values should be maximum across aggregations
         assertEquals(
             List.of(new FloatSample(1000L, 20.0), new FloatSample(2000L, 40.0), new FloatSample(3000L, 60.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -182,7 +182,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
                 new FloatSample(20000L, 20.0),  // 20s: only ts1
                 new FloatSample(30000L, 40.0)   // 30s: only ts2
             ),
-            maxed.getSamples()
+            maxed.getSamples().toList()
         );
     }
 
@@ -207,7 +207,7 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
                 new FloatSample(20000L, 15.0),  // 20s: only ts1
                 new FloatSample(30000L, 35.0)   // 30s: only ts2
             ),
-            maxed.getSamples()
+            maxed.getSamples().toList()
         );
     }
 
@@ -237,7 +237,10 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
         TimeSeries maxed = result.get(0);
         assertEquals("service1", maxed.getLabels().get("service"));
         assertEquals(3, maxed.getSamples().size());
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)), maxed.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
+            maxed.getSamples().toList()
+        );
     }
 
     public void testProcessGroupWithMultipleTimeSeries() {
@@ -249,7 +252,10 @@ public class MaxStageTests extends AbstractWireSerializingTestCase<MaxStage> {
         TimeSeries maxed = result.get(0);
         assertEquals("service1", maxed.getLabels().get("service"));
         assertEquals(3, maxed.getSamples().size());
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)), maxed.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
+            maxed.getSamples().toList()
+        );
     }
 
     // Comprehensive test data - all tests use this same dataset

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/MinStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/MinStageTests.java
@@ -48,7 +48,7 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
                 new FloatSample(2000L, 2.0),  // min(20, 40, 15, 6, 2) = 2
                 new FloatSample(3000L, 3.0)   // min(30, 60, 25, 9, 3) = 3
             ),
-            minned.getSamples()
+            minned.getSamples().toList()
         );
     }
 
@@ -69,7 +69,7 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
                 new FloatSample(2000L, 20.0), // min(20, 40) = 20
                 new FloatSample(3000L, 30.0)  // min(30, 60) = 30
             ),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // Find the service1 group (ts3) - unchanged since single series
@@ -78,7 +78,7 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
         assertEquals(3, service1Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // Find the service2 group (ts4) - unchanged since single series
@@ -87,7 +87,7 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
         assertEquals(3, service2Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -107,7 +107,10 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
         assertEquals(3, reduced.getSamples().size());
 
         // Values should be minimum across aggregations
-        assertEquals(List.of(new FloatSample(1000L, 1.0), new FloatSample(2000L, 2.0), new FloatSample(3000L, 3.0)), reduced.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 1.0), new FloatSample(2000L, 2.0), new FloatSample(3000L, 3.0)),
+            reduced.getSamples().toList()
+        );
     }
 
     public void testReduceNonFinalReduce() throws Exception {
@@ -126,7 +129,10 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
         assertEquals(3, reduced.getSamples().size());
 
         // Values should be minimum across aggregations
-        assertEquals(List.of(new FloatSample(1000L, 1.0), new FloatSample(2000L, 2.0), new FloatSample(3000L, 3.0)), reduced.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 1.0), new FloatSample(2000L, 2.0), new FloatSample(3000L, 3.0)),
+            reduced.getSamples().toList()
+        );
     }
 
     public void testFromArgsNoGrouping() {
@@ -176,7 +182,7 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
                 new FloatSample(20000L, 20.0),  // 20s: only ts1
                 new FloatSample(30000L, 40.0)   // 30s: only ts2
             ),
-            minned.getSamples()
+            minned.getSamples().toList()
         );
     }
 
@@ -201,7 +207,7 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
                 new FloatSample(20000L, 15.0),  // 20s: only ts1
                 new FloatSample(30000L, 35.0)   // 30s: only ts2
             ),
-            minned.getSamples()
+            minned.getSamples().toList()
         );
     }
 
@@ -231,7 +237,10 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
         TimeSeries minned = result.get(0);
         assertEquals("service1", minned.getLabels().get("service"));
         assertEquals(3, minned.getSamples().size());
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)), minned.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
+            minned.getSamples().toList()
+        );
     }
 
     public void testProcessGroupWithMultipleTimeSeries() {
@@ -243,7 +252,10 @@ public class MinStageTests extends AbstractWireSerializingTestCase<MinStage> {
         TimeSeries minned = result.get(0);
         assertEquals("service1", minned.getLabels().get("service"));
         assertEquals(3, minned.getSamples().size());
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)), minned.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
+            minned.getSamples().toList()
+        );
     }
 
     // Comprehensive test data - all tests use this same dataset

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/MovingStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/MovingStageTests.java
@@ -81,7 +81,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 12.0),  // sum([3,4,5])
             new FloatSample(60L, 15.0)   // sum([4,5,6])
         );
-        assertSamplesEqual("Sum Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Sum Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -93,7 +93,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 8.0),   // sum([3,null,5])
             new FloatSample(60L, 5.0)    // sum([null,5,null])
         );
-        assertSamplesEqual("Sum Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Sum Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result: no samples
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");
@@ -150,7 +150,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 40.0),  // avg([30,40,50]) = 40
             new FloatSample(60L, 50.0)   // avg([40,50,60]) = 50
         );
-        assertSamplesEqual("Avg Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Avg Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: average only over non-null values
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -162,7 +162,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 40.0),  // avg([30,50]) = 40
             new FloatSample(60L, 50.0)   // avg([50]) = 50
         );
-        assertSamplesEqual("Avg Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Avg Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");
@@ -219,7 +219,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 1.0),   // min([7,1,8]) = 1
             new FloatSample(60L, 1.0)    // min([1,8,2]) = 1
         );
-        assertSamplesEqual("Min Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Min Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: nulls treated as +infinity
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -231,7 +231,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 7.0),   // min([7,+inf,8]) = 7
             new FloatSample(60L, 8.0)    // min([+inf,8,+inf]) = 8
         );
-        assertSamplesEqual("Min Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Min Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");
@@ -288,7 +288,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 9.0),   // max([2,9,3]) = 9
             new FloatSample(60L, 9.0)    // max([9,3,7]) = 9
         );
-        assertSamplesEqual("Max Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Max Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: nulls treated as -infinity
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -300,7 +300,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 3.0),   // max([2,-inf,3]) = 3
             new FloatSample(60L, 3.0)    // max([-inf,3,-inf]) = 3
         );
-        assertSamplesEqual("Max Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Max Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");
@@ -357,7 +357,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 5.0),   // median([3,7,5]) = 5 (sorted: [3,5,7], midpoint=1)
             new FloatSample(60L, 5.0)    // median([7,5,2]) = 5 (sorted: [2,5,7], midpoint=1)
         );
-        assertSamplesEqual("Median Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Median Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: nulls excluded from median calculation
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -369,7 +369,7 @@ public class MovingStageTests extends AbstractWireSerializingTestCase<MovingStag
             new FloatSample(50L, 3.0),   // median([3,5]) = 3 (midpoint=0)
             new FloatSample(60L, 5.0)    // median([5]) = 5
         );
-        assertSamplesEqual("Median Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Median Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/MultiplyStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/MultiplyStageTests.java
@@ -52,7 +52,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "Values should be multiplied correctly",
             List.of(new FloatSample(1000L, 3000.0), new FloatSample(2000L, 144000.0), new FloatSample(3000L, 1215000.0)),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 
@@ -74,7 +74,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
                 new FloatSample(2000L, 800.0), // 20 * 40
                 new FloatSample(3000L, 1800.0)  // 30 * 60
             ),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // Find the service1 group (ts3)
@@ -84,7 +84,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service1 group values should match",
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // Find the service2 group (ts4)
@@ -94,7 +94,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service2 group values should match",
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -117,7 +117,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "Values should be multiplied across aggregations",
             List.of(new FloatSample(1000L, 3000.0), new FloatSample(2000L, 144000.0), new FloatSample(3000L, 1215000.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -140,7 +140,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "Values should be multiplied across aggregations",
             List.of(new FloatSample(1000L, 3000.0), new FloatSample(2000L, 144000.0), new FloatSample(3000L, 1215000.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -166,7 +166,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "api group values should be multiplied correctly",
             List.of(new FloatSample(1000L, 200.0), new FloatSample(2000L, 800.0), new FloatSample(3000L, 1800.0)),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // service1 group: ts3 only = [5, 15, 25]
@@ -179,7 +179,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service1 group values should match",
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // service2 group: ts4 only = [3, 6, 9]
@@ -192,7 +192,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service2 group values should match",
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -218,7 +218,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "api group values should be multiplied correctly",
             List.of(new FloatSample(1000L, 200.0), new FloatSample(2000L, 800.0), new FloatSample(3000L, 1800.0)),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // service1 group: ts3 only = [5, 15, 25]
@@ -231,7 +231,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service1 group values should match",
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // service2 group: ts4 only = [3, 6, 9]
@@ -244,7 +244,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service2 group values should match",
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -282,7 +282,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "Values should be multiplied across aggregations",
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 12.0), new FloatSample(3000L, 27.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -334,7 +334,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
                 new FloatSample(20000L, 20.0),  // 20s: only ts1
                 new FloatSample(30000L, 40.0)   // 30s: only ts2
             ),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 
@@ -360,7 +360,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
                 new FloatSample(20000L, 15.0),  // 20s: only ts1
                 new FloatSample(30000L, 35.0)   // 30s: only ts2
             ),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 
@@ -388,7 +388,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
                 new FloatSample(2000L, 40.0),  // NaN skipped, only ts2 contributes: 40
                 new FloatSample(3000L, 30.0)   // NaN skipped, only ts1 contributes: 30
             ),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 
@@ -411,7 +411,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
                 new FloatSample(1000L, 200.0),  // 10 * 20
                 new FloatSample(3000L, 1800.0)   // 30 * 60
             ),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 
@@ -432,7 +432,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service1 group NaN values should be skipped",
             List.of(new FloatSample(1000L, 5.0), new FloatSample(3000L, 25.0)),
-            service1.getSamples()
+            service1.getSamples().toList()
         );
 
         // Find service2 group
@@ -442,7 +442,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "service2 group NaN values should be skipped",
             List.of(new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2.getSamples()
+            service2.getSamples().toList()
         );
     }
 
@@ -471,7 +471,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "Single time series group values should match",
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 
@@ -487,7 +487,7 @@ public class MultiplyStageTests extends AbstractWireSerializingTestCase<Multiply
         assertSamplesEqual(
             "Single time series group values should match",
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            multiplied.getSamples()
+            multiplied.getSamples().toList()
         );
     }
 

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/PerSecondRateStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/PerSecondRateStageTests.java
@@ -75,7 +75,7 @@ public class PerSecondRateStageTests extends AbstractWireSerializingTestCase<Per
         List<TimeSeries> result = stage.process(List.of(series));
 
         assertEquals(1, result.size());
-        assertSamplesEqual("Regular increasing series", expected, result.get(0).getSamples());
+        assertSamplesEqual("Regular increasing series", expected, result.get(0).getSamples().toList());
     }
 
     /**
@@ -107,7 +107,7 @@ public class PerSecondRateStageTests extends AbstractWireSerializingTestCase<Per
         List<TimeSeries> result = stage.process(List.of(series));
 
         assertEquals(1, result.size());
-        assertSamplesEqual("Exponentially increasing series", expected, result.get(0).getSamples());
+        assertSamplesEqual("Exponentially increasing series", expected, result.get(0).getSamples().toList());
     }
 
     /**
@@ -143,7 +143,7 @@ public class PerSecondRateStageTests extends AbstractWireSerializingTestCase<Per
         List<TimeSeries> result = stage.process(List.of(series));
 
         assertEquals(1, result.size());
-        assertSamplesEqual("Regular increasing series with reset", expected, result.get(0).getSamples());
+        assertSamplesEqual("Regular increasing series with reset", expected, result.get(0).getSamples().toList());
     }
 
     /**
@@ -180,7 +180,7 @@ public class PerSecondRateStageTests extends AbstractWireSerializingTestCase<Per
         List<TimeSeries> result = stage.process(List.of(series));
 
         assertEquals(1, result.size());
-        assertSamplesEqual("Regular increasing series with 20s interval", expected, result.get(0).getSamples());
+        assertSamplesEqual("Regular increasing series with 20s interval", expected, result.get(0).getSamples().toList());
     }
 
     /**
@@ -192,7 +192,7 @@ public class PerSecondRateStageTests extends AbstractWireSerializingTestCase<Per
         List<Sample> input = new ArrayList<>();
         input.add(new FloatSample(0, 0f));
         input.add(new FloatSample(10000, 10f));
-        input.add(null);  // Missing at timestamp 20000
+        input.add(new FloatSample(20000, Double.NaN));  // Missing at timestamp 20000
         input.add(new FloatSample(30000, 20f));
         input.add(new FloatSample(40000, 30f));
 
@@ -207,7 +207,7 @@ public class PerSecondRateStageTests extends AbstractWireSerializingTestCase<Per
         List<TimeSeries> result = stage.process(List.of(series));
 
         assertEquals(1, result.size());
-        assertSamplesEqual("Mixed series with missing values", expected, result.get(0).getSamples());
+        assertSamplesEqual("Mixed series with missing values", expected, result.get(0).getSamples().toList());
     }
 
     public void testConstructorInvalidInterval() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/PerSecondStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/PerSecondStageTests.java
@@ -55,7 +55,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
 
         // Rate calculations: (1-0)/10s = 0.1/s, (2-1)/10s = 0.1/s, (3-2)/10s = 0.1/s
         List<Sample> expectedSamples = List.of(new FloatSample(10000L, 0.1), new FloatSample(20000L, 0.1), new FloatSample(30000L, 0.1));
-        assertSamplesEqual("Linearly increasing series", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Linearly increasing series", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -83,7 +83,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
 
         // Rate calculations: (10-0)/10s = 1/s, (30-10)/10s = 2/s, (60-30)/10s = 3/s
         List<Sample> expectedSamples = List.of(new FloatSample(10000L, 1.0), new FloatSample(20000L, 2.0), new FloatSample(30000L, 3.0));
-        assertSamplesEqual("Nonlinear increasing series", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Nonlinear increasing series", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -115,7 +115,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
             new FloatSample(20000L, 0.1),  // rate between 0s and 20s
             new FloatSample(30000L, 0.1)   // rate between 20s and 30s
         );
-        assertSamplesEqual("Missing data points test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Missing data points test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -139,7 +139,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
         assertEquals(1, resultSeries.getSamples().size()); // Only the valid positive rate
 
         List<Sample> expectedSamples = List.of(new FloatSample(3000L, 10.0));
-        assertSamplesEqual("Counter reset test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Counter reset test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -158,7 +158,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
         TimeSeries resultSeries = result.get(0);
         assertEquals(0, resultSeries.getSamples().size()); // Empty result - can't calculate rate with one point
 
-        assertSamplesEqual("Single sample test", List.of(), resultSeries.getSamples());
+        assertSamplesEqual("Single sample test", List.of(), resultSeries.getSamples().toList());
     }
 
     /**
@@ -177,7 +177,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
         TimeSeries resultSeries = result.get(0);
         assertEquals(0, resultSeries.getSamples().size());
 
-        assertSamplesEqual("Empty time series test", List.of(), resultSeries.getSamples());
+        assertSamplesEqual("Empty time series test", List.of(), resultSeries.getSamples().toList());
     }
 
     /**
@@ -209,11 +209,11 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
 
         // First time series result
         List<Sample> expectedSamples1 = List.of(new FloatSample(2000L, 20.0));
-        assertSamplesEqual("First time series", expectedSamples1, result.get(0).getSamples());
+        assertSamplesEqual("First time series", expectedSamples1, result.get(0).getSamples().toList());
 
         // Second time series result
         List<Sample> expectedSamples2 = List.of(new FloatSample(3000L, 25.0));
-        assertSamplesEqual("Second time series", expectedSamples2, result.get(1).getSamples());
+        assertSamplesEqual("Second time series", expectedSamples2, result.get(1).getSamples().toList());
     }
 
     /**
@@ -236,7 +236,7 @@ public class PerSecondStageTests extends AbstractWireSerializingTestCase<PerSeco
         assertEquals(1, resultSeries.getSamples().size());
 
         List<Sample> expectedSamples = List.of(new FloatSample(2000L, 0.0));
-        assertSamplesEqual("Zero rate test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Zero rate test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/PercentileOfSeriesStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/PercentileOfSeriesStageTests.java
@@ -90,56 +90,56 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         // t=2000: [100,200,300,400] -> fractionalRank=0.0*4=0.0, ceil=0, <=1 -> 100
         // t=3000: [15,25,35] -> fractionalRank=0.0*3=0.0, ceil=0, <=1 -> 15
         List<Sample> expectedP0 = List.of(new FloatSample(1000L, 10.0f), new FloatSample(2000L, 100.0f), new FloatSample(3000L, 15.0f));
-        assertSamplesEqual("0th percentile (minimum)", expectedP0, p0Series.getSamples());
+        assertSamplesEqual("0th percentile (minimum)", expectedP0, p0Series.getSamples().toList());
 
         // Verify 30th percentile
         // t=1000: [10,20,30,40,50] -> fractionalRank=0.3*5=1.5, ceil=2, index=1 -> 20
         // t=2000: [100,200,300,400] -> fractionalRank=0.3*4=1.2, ceil=2, index=1 -> 200
         // t=3000: [15,25,35] -> fractionalRank=0.3*3=0.9, ceil=1, <=1 -> 15
         List<Sample> expectedP30 = List.of(new FloatSample(1000L, 20.0f), new FloatSample(2000L, 200.0f), new FloatSample(3000L, 15.0f));
-        assertSamplesEqual("30th percentile", expectedP30, p30Series.getSamples());
+        assertSamplesEqual("30th percentile", expectedP30, p30Series.getSamples().toList());
 
         // Verify 50th percentile (median)
         // t=1000: [10,20,30,40,50] -> fractionalRank=0.5*5=2.5, ceil=3, index=2 -> 30
         // t=2000: [100,200,300,400] -> fractionalRank=0.5*4=2.0, ceil=2, index=1 -> 200
         // t=3000: [15,25,35] -> fractionalRank=0.5*3=1.5, ceil=2, index=1 -> 25
         List<Sample> expectedP50 = List.of(new FloatSample(1000L, 30.0f), new FloatSample(2000L, 200.0f), new FloatSample(3000L, 25.0f));
-        assertSamplesEqual("50th percentile (median)", expectedP50, p50Series.getSamples());
+        assertSamplesEqual("50th percentile (median)", expectedP50, p50Series.getSamples().toList());
 
         // Verify 90th percentile
         // t=1000: [10,20,30,40,50] -> fractionalRank=0.9*5=4.5, ceil=5, index=4 -> 50
         // t=2000: [100,200,300,400] -> fractionalRank=0.9*4=3.6, ceil=4, index=3 -> 400
         // t=3000: [15,25,35] -> fractionalRank=0.9*3=2.7, ceil=3, index=2 -> 35
         List<Sample> expectedP90 = List.of(new FloatSample(1000L, 50.0f), new FloatSample(2000L, 400.0f), new FloatSample(3000L, 35.0f));
-        assertSamplesEqual("90th percentile", expectedP90, p90Series.getSamples());
+        assertSamplesEqual("90th percentile", expectedP90, p90Series.getSamples().toList());
 
         // Verify 95th percentile
         // t=1000: [10,20,30,40,50] -> fractionalRank=0.95*5=4.75, ceil=5, index=4 -> 50
         // t=2000: [100,200,300,400] -> fractionalRank=0.95*4=3.8, ceil=4, index=3 -> 400
         // t=3000: [15,25,35] -> fractionalRank=0.95*3=2.85, ceil=3, index=2 -> 35
         List<Sample> expectedP95 = List.of(new FloatSample(1000L, 50.0f), new FloatSample(2000L, 400.0f), new FloatSample(3000L, 35.0f));
-        assertSamplesEqual("95th percentile", expectedP95, p95Series.getSamples());
+        assertSamplesEqual("95th percentile", expectedP95, p95Series.getSamples().toList());
 
         // Verify 99th percentile
         // t=1000: [10,20,30,40,50] -> fractionalRank=0.99*5=4.95, ceil=5, index=4 -> 50
         // t=2000: [100,200,300,400] -> fractionalRank=0.99*4=3.96, ceil=4, index=3 -> 400
         // t=3000: [15,25,35] -> fractionalRank=0.99*3=2.97, ceil=3, index=2 -> 35
         List<Sample> expectedP99 = List.of(new FloatSample(1000L, 50.0f), new FloatSample(2000L, 400.0f), new FloatSample(3000L, 35.0f));
-        assertSamplesEqual("99th percentile", expectedP99, p99Series.getSamples());
+        assertSamplesEqual("99th percentile", expectedP99, p99Series.getSamples().toList());
 
         // Verify 99.5th percentile (validates decimal percentile label formatting)
         // t=1000: [10,20,30,40,50] -> fractionalRank=0.995*5=4.975, ceil=5, index=4 -> 50
         // t=2000: [100,200,300,400] -> fractionalRank=0.995*4=3.98, ceil=4, index=3 -> 400
         // t=3000: [15,25,35] -> fractionalRank=0.995*3=2.985, ceil=3, index=2 -> 35
         List<Sample> expectedP99_5 = List.of(new FloatSample(1000L, 50.0f), new FloatSample(2000L, 400.0f), new FloatSample(3000L, 35.0f));
-        assertSamplesEqual("99.5th percentile", expectedP99_5, p99_5Series.getSamples());
+        assertSamplesEqual("99.5th percentile", expectedP99_5, p99_5Series.getSamples().toList());
 
         // Verify 100th percentile (maximum)
         // t=1000: [10,20,30,40,50] -> fractionalRank=1.0*5=5.0, ceil=5, index=4 -> 50
         // t=2000: [100,200,300,400] -> fractionalRank=1.0*4=4.0, ceil=4, index=3 -> 400
         // t=3000: [15,25,35] -> fractionalRank=1.0*3=3.0, ceil=3, index=2 -> 35
         List<Sample> expectedP100 = List.of(new FloatSample(1000L, 50.0f), new FloatSample(2000L, 400.0f), new FloatSample(3000L, 35.0f));
-        assertSamplesEqual("100th percentile (maximum)", expectedP100, p100Series.getSamples());
+        assertSamplesEqual("100th percentile (maximum)", expectedP100, p100Series.getSamples().toList());
     }
 
     /**
@@ -166,7 +166,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         // t=1000: [10,20] -> median at index 0 (ceil(0.5*2)=1, index=0) -> 10
         // t=2000: [30,40] -> median at index 0 (ceil(0.5*2)=1, index=0) -> 30
         List<Sample> expected = List.of(new FloatSample(1000L, 10.0f), new FloatSample(2000L, 30.0f));
-        assertSamplesEqual("50th percentile", expected, p50Series.getSamples());
+        assertSamplesEqual("50th percentile", expected, p50Series.getSamples().toList());
     }
 
     /**
@@ -517,7 +517,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group1 P0",
             List.of(new FloatSample(1000L, 10.0f), new FloatSample(2000L, 100.0f)),
-            group1P0List.get(0).getSamples()
+            group1P0List.get(0).getSamples().toList()
         );
 
         // 30th percentile: fractionalRank=0.3*3=0.9, ceil=1, rankAsInt=1, <=1 -> first element (no interpolation possible)
@@ -526,7 +526,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group1 P30",
             List.of(new FloatSample(1000L, 10.0f), new FloatSample(2000L, 100.0f)),
-            group1P30List.get(0).getSamples()
+            group1P30List.get(0).getSamples().toList()
         );
 
         // 50th percentile: fractionalRank=0.5*3=1.5, ceil=2, rankAsInt=2, index=1 -> 20
@@ -536,7 +536,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group1 P50",
             List.of(new FloatSample(1000L, 15.0f), new FloatSample(2000L, 150.0f)),
-            group1P50List.get(0).getSamples()
+            group1P50List.get(0).getSamples().toList()
         );
 
         // 70th percentile: fractionalRank=0.7*3=2.1, ceil=3, rankAsInt=3, index=2 -> 30
@@ -546,7 +546,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group1 P70",
             List.of(new FloatSample(1000L, 21.0f), new FloatSample(2000L, 210.0f)),
-            group1P70List.get(0).getSamples()
+            group1P70List.get(0).getSamples().toList()
         );
 
         // 90th percentile: fractionalRank=0.9*3=2.7, ceil=3, rankAsInt=3, index=2 -> 30
@@ -556,7 +556,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group1 P90",
             List.of(new FloatSample(1000L, 27.0f), new FloatSample(2000L, 270.0f)),
-            group1P90List.get(0).getSamples()
+            group1P90List.get(0).getSamples().toList()
         );
 
         // 100th percentile: fractionalRank=1.0*3=3.0, ceil=3, rankAsInt=3, index=2 -> 30
@@ -566,7 +566,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group1 P100",
             List.of(new FloatSample(1000L, 30.0f), new FloatSample(2000L, 300.0f)),
-            group1P100List.get(0).getSamples()
+            group1P100List.get(0).getSamples().toList()
         );
 
         // ========== Group 2: region=us-west, env=dev (values: [40,50]) ==========
@@ -577,7 +577,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group2 P0",
             List.of(new FloatSample(1000L, 40.0f), new FloatSample(2000L, 400.0f)),
-            group2P0List.get(0).getSamples()
+            group2P0List.get(0).getSamples().toList()
         );
 
         // 30th percentile: fractionalRank=0.3*2=0.6, ceil=1, rankAsInt=1, <=1 -> first element
@@ -586,7 +586,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group2 P30",
             List.of(new FloatSample(1000L, 40.0f), new FloatSample(2000L, 400.0f)),
-            group2P30List.get(0).getSamples()
+            group2P30List.get(0).getSamples().toList()
         );
 
         // 50th percentile: fractionalRank=0.5*2=1.0, ceil=1, rankAsInt=1, <=1 -> first element
@@ -595,7 +595,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group2 P50",
             List.of(new FloatSample(1000L, 40.0f), new FloatSample(2000L, 400.0f)),
-            group2P50List.get(0).getSamples()
+            group2P50List.get(0).getSamples().toList()
         );
 
         // 70th percentile: fractionalRank=0.7*2=1.4, ceil=2, rankAsInt=2, index=1 -> 50
@@ -605,7 +605,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group2 P70",
             List.of(new FloatSample(1000L, 44.0f), new FloatSample(2000L, 440.0f)),
-            group2P70List.get(0).getSamples()
+            group2P70List.get(0).getSamples().toList()
         );
 
         // 90th percentile: fractionalRank=0.9*2=1.8, ceil=2, rankAsInt=2, index=1 -> 50
@@ -615,7 +615,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group2 P90",
             List.of(new FloatSample(1000L, 48.0f), new FloatSample(2000L, 480.0f)),
-            group2P90List.get(0).getSamples()
+            group2P90List.get(0).getSamples().toList()
         );
 
         // 100th percentile: fractionalRank=1.0*2=2.0, ceil=2, rankAsInt=2, index=1 -> 50
@@ -625,7 +625,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group2 P100",
             List.of(new FloatSample(1000L, 50.0f), new FloatSample(2000L, 500.0f)),
-            group2P100List.get(0).getSamples()
+            group2P100List.get(0).getSamples().toList()
         );
 
         // ========== Group 3: region=us-east, env=prod (values: [5,15,25]) ==========
@@ -636,7 +636,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group3 P0",
             List.of(new FloatSample(1000L, 5.0f), new FloatSample(2000L, 50.0f)),
-            group3P0List.get(0).getSamples()
+            group3P0List.get(0).getSamples().toList()
         );
 
         // 30th percentile: fractionalRank=0.3*3=0.9, ceil=1, rankAsInt=1, <=1 -> first element
@@ -645,7 +645,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group3 P30",
             List.of(new FloatSample(1000L, 5.0f), new FloatSample(2000L, 50.0f)),
-            group3P30List.get(0).getSamples()
+            group3P30List.get(0).getSamples().toList()
         );
 
         // 50th percentile: fractionalRank=0.5*3=1.5, ceil=2, rankAsInt=2, index=1 -> 15
@@ -655,7 +655,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group3 P50",
             List.of(new FloatSample(1000L, 10.0f), new FloatSample(2000L, 100.0f)),
-            group3P50List.get(0).getSamples()
+            group3P50List.get(0).getSamples().toList()
         );
 
         // 70th percentile: fractionalRank=0.7*3=2.1, ceil=3, rankAsInt=3, index=2 -> 25
@@ -665,7 +665,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group3 P70",
             List.of(new FloatSample(1000L, 16.0f), new FloatSample(2000L, 160.0f)),
-            group3P70List.get(0).getSamples()
+            group3P70List.get(0).getSamples().toList()
         );
 
         // 90th percentile: fractionalRank=0.9*3=2.7, ceil=3, rankAsInt=3, index=2 -> 25
@@ -675,7 +675,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group3 P90",
             List.of(new FloatSample(1000L, 22.0f), new FloatSample(2000L, 220.0f)),
-            group3P90List.get(0).getSamples()
+            group3P90List.get(0).getSamples().toList()
         );
 
         // 100th percentile: fractionalRank=1.0*3=3.0, ceil=3, rankAsInt=3, index=2 -> 25
@@ -685,7 +685,7 @@ public class PercentileOfSeriesStageTests extends AbstractWireSerializingTestCas
         assertSamplesEqual(
             "Group3 P100",
             List.of(new FloatSample(1000L, 25.0f), new FloatSample(2000L, 250.0f)),
-            group3P100List.get(0).getSamples()
+            group3P100List.get(0).getSamples().toList()
         );
     }
 

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/RemoveEmptyStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/RemoveEmptyStageTests.java
@@ -54,7 +54,7 @@ public class RemoveEmptyStageTests extends AbstractWireSerializingTestCase<Remov
         assertEquals(1, firstResult.size());
         TimeSeries timeSeries = firstResult.getFirst();
         assertEquals(1, timeSeries.getSamples().size());
-        assertEquals(2.0, timeSeries.getSamples().get(0).getValue(), 0.0);
+        assertEquals(2.0, timeSeries.getSamples().getValue(0), 0.0);
 
         // Test Idempotent
         // Act
@@ -64,7 +64,7 @@ public class RemoveEmptyStageTests extends AbstractWireSerializingTestCase<Remov
         assertEquals(1, secondResult.size());
         timeSeries = secondResult.getFirst();
         assertEquals(1, timeSeries.getSamples().size());
-        assertEquals(2.0, timeSeries.getSamples().get(0).getValue(), 0.0);
+        assertEquals(2.0, timeSeries.getSamples().getValue(0), 0.0);
 
     }
 
@@ -104,7 +104,7 @@ public class RemoveEmptyStageTests extends AbstractWireSerializingTestCase<Remov
             new FloatSample(2000L, Double.NaN),
             new FloatSample(3000L, 4.0)
         );
-        assertSamplesEqual("Remaining series should contain valid samples", expectedSamples, remainingSeries.getSamples(), 0.001);
+        assertSamplesEqual("Remaining series should contain valid samples", expectedSamples, remainingSeries.getSamples().toList(), 0.001);
     }
 
     public void testProcessWithEmptyInput() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/RoundStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/RoundStageTests.java
@@ -42,7 +42,7 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         Labels labels = ByteLabels.fromMap(Map.of("test", "value"));
         TimeSeries inputSeries = new TimeSeries(Arrays.asList(new FloatSample(1000L, 1.7)), labels, 1000L, 1000L, 1000L, "test");
         List<TimeSeries> result = roundStage.process(Arrays.asList(inputSeries));
-        assertEquals(2.0, result.get(0).getSamples().get(0).getValue(), 0.001); // 1.7 -> 2 (precision=0)
+        assertEquals(2.0, result.get(0).getSamples().getValue(0), 0.001); // 1.7 -> 2 (precision=0)
     }
 
     public void testConstructorWithPrecision() {
@@ -56,7 +56,7 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         Labels labels = ByteLabels.fromMap(Map.of("test", "value"));
         TimeSeries inputSeries = new TimeSeries(Arrays.asList(new FloatSample(1000L, 1.234)), labels, 1000L, 1000L, 1000L, "test");
         List<TimeSeries> result = roundStage.process(Arrays.asList(inputSeries));
-        assertEquals(1.23, result.get(0).getSamples().get(0).getValue(), 0.001); // 1.234 -> 1.23 (precision=2)
+        assertEquals(1.23, result.get(0).getSamples().getValue(0), 0.001); // 1.234 -> 1.23 (precision=2)
     }
 
     public void testConstructorWithNegativePrecision() {
@@ -70,7 +70,7 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         Labels labels = ByteLabels.fromMap(Map.of("test", "value"));
         TimeSeries inputSeries = new TimeSeries(Arrays.asList(new FloatSample(1000L, 150.0)), labels, 1000L, 1000L, 1000L, "test");
         List<TimeSeries> result = roundStage.process(Arrays.asList(inputSeries));
-        assertEquals(150.0, result.get(0).getSamples().get(0).getValue(), 0.001); // 150 -> 150 (precision=-2)
+        assertEquals(150.0, result.get(0).getSamples().getValue(0), 0.001); // 150 -> 150 (precision=-2)
     }
 
     // ========== Basic Functionality Tests ==========
@@ -89,9 +89,9 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         assertEquals(1, result.size());
         TimeSeries roundedTimeSeries = result.get(0);
         assertEquals(3, roundedTimeSeries.getSamples().size());
-        assertEquals(2.0, roundedTimeSeries.getSamples().get(0).getValue(), 0.001); // 1.7 -> 2
-        assertEquals(2.0, roundedTimeSeries.getSamples().get(1).getValue(), 0.001); // 2.3 -> 2
-        assertEquals(4.0, roundedTimeSeries.getSamples().get(2).getValue(), 0.001); // 3.8 -> 4
+        assertEquals(2.0, roundedTimeSeries.getSamples().getValue(0), 0.001); // 1.7 -> 2
+        assertEquals(2.0, roundedTimeSeries.getSamples().getValue(1), 0.001); // 2.3 -> 2
+        assertEquals(4.0, roundedTimeSeries.getSamples().getValue(2), 0.001); // 3.8 -> 4
         assertEquals(labels, roundedTimeSeries.getLabels());
         assertEquals("test-series", roundedTimeSeries.getAlias());
     }
@@ -110,9 +110,9 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         assertEquals(1, result.size());
         TimeSeries roundedTimeSeries = result.get(0);
         assertEquals(3, roundedTimeSeries.getSamples().size());
-        assertEquals(1.23, roundedTimeSeries.getSamples().get(0).getValue(), 0.001); // 1.234 -> 1.23
-        assertEquals(2.57, roundedTimeSeries.getSamples().get(1).getValue(), 0.001); // 2.567 -> 2.57
-        assertEquals(3.89, roundedTimeSeries.getSamples().get(2).getValue(), 0.001); // 3.891 -> 3.89
+        assertEquals(1.23, roundedTimeSeries.getSamples().getValue(0), 0.001); // 1.234 -> 1.23
+        assertEquals(2.57, roundedTimeSeries.getSamples().getValue(1), 0.001); // 2.567 -> 2.57
+        assertEquals(3.89, roundedTimeSeries.getSamples().getValue(2), 0.001); // 3.891 -> 3.89
     }
 
     public void testProcessWithNegativePrecision() {
@@ -133,9 +133,9 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         assertEquals(1, result.size());
         TimeSeries roundedTimeSeries = result.get(0);
         assertEquals(3, roundedTimeSeries.getSamples().size());
-        assertEquals(123.45, roundedTimeSeries.getSamples().get(0).getValue(), 0.001); // 123.45 -> 123.45 (unchanged)
-        assertEquals(267.89, roundedTimeSeries.getSamples().get(1).getValue(), 0.001); // 267.89 -> 267.89 (unchanged)
-        assertEquals(391.23, roundedTimeSeries.getSamples().get(2).getValue(), 0.001); // 391.23 -> 391.23 (unchanged)
+        assertEquals(123.45, roundedTimeSeries.getSamples().getValue(0), 0.001); // 123.45 -> 123.45 (unchanged)
+        assertEquals(267.89, roundedTimeSeries.getSamples().getValue(1), 0.001); // 267.89 -> 267.89 (unchanged)
+        assertEquals(391.23, roundedTimeSeries.getSamples().getValue(2), 0.001); // 391.23 -> 391.23 (unchanged)
     }
 
     public void testProcessWithMultipleTimeSeries() {
@@ -152,8 +152,8 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
 
         // Assert
         assertEquals(2, result.size());
-        assertEquals(4.3, result.get(0).getSamples().get(0).getValue(), 0.001); // 4.25 -> 4.3
-        assertEquals(8.8, result.get(1).getSamples().get(0).getValue(), 0.001); // 8.76 -> 8.8
+        assertEquals(4.3, result.get(0).getSamples().getValue(0), 0.001); // 4.25 -> 4.3
+        assertEquals(8.8, result.get(1).getSamples().getValue(0), 0.001); // 8.76 -> 8.8
     }
 
     public void testProcessWithEmptyInput() {
@@ -177,7 +177,7 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         List<TimeSeries> result = roundStage.process(Arrays.asList(inputTimeSeries));
 
         // Assert
-        assertEquals(0.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(0.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessWithNegativeValues() {
@@ -197,8 +197,8 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         List<TimeSeries> result = roundStage.process(Arrays.asList(inputTimeSeries));
 
         // Assert
-        assertEquals(-3.3, result.get(0).getSamples().get(0).getValue(), 0.001); // -3.27 -> -3.3
-        assertEquals(-5.8, result.get(0).getSamples().get(1).getValue(), 0.001); // -5.83 -> -5.8
+        assertEquals(-3.3, result.get(0).getSamples().getValue(0), 0.001); // -3.27 -> -3.3
+        assertEquals(-5.8, result.get(0).getSamples().getValue(1), 0.001); // -5.83 -> -5.8
     }
 
     // ========== Edge Cases Tests ==========
@@ -220,7 +220,7 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         List<TimeSeries> result = roundStage.process(Arrays.asList(inputTimeSeries));
 
         // Assert
-        assertEquals(0.000012, result.get(0).getSamples().get(0).getValue(), 0.0000001);
+        assertEquals(0.000012, result.get(0).getSamples().getValue(0), 0.0000001);
     }
 
     // ========== Metadata Preservation Tests ==========
@@ -296,7 +296,7 @@ public class RoundStageTests extends AbstractWireSerializingTestCase<RoundStage>
         List<TimeSeries> secondRound = roundStage.process(firstRound);
 
         // Results should be identical
-        assertEquals(firstRound.get(0).getSamples().get(0).getValue(), secondRound.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(firstRound.get(0).getSamples().getValue(0), secondRound.get(0).getSamples().getValue(0), 0.001);
     }
 
     // ========== Null Input Tests ==========

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/ScaleStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/ScaleStageTests.java
@@ -60,9 +60,9 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
         assertEquals(1, result.size());
         TimeSeries scaledTimeSeries = result.get(0);
         assertEquals(3, scaledTimeSeries.getSamples().size());
-        assertEquals(2.0, scaledTimeSeries.getSamples().get(0).getValue(), 0.001);
-        assertEquals(4.0, scaledTimeSeries.getSamples().get(1).getValue(), 0.001);
-        assertEquals(6.0, scaledTimeSeries.getSamples().get(2).getValue(), 0.001);
+        assertEquals(2.0, scaledTimeSeries.getSamples().getValue(0), 0.001);
+        assertEquals(4.0, scaledTimeSeries.getSamples().getValue(1), 0.001);
+        assertEquals(6.0, scaledTimeSeries.getSamples().getValue(2), 0.001);
         assertEquals(labels, scaledTimeSeries.getLabels());
         assertEquals("test-series", scaledTimeSeries.getAlias());
     }
@@ -81,8 +81,8 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
 
         // Assert
         assertEquals(2, result.size());
-        assertEquals(2.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(4.0, result.get(1).getSamples().get(0).getValue(), 0.001);
+        assertEquals(2.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(4.0, result.get(1).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessWithEmptyInput() {
@@ -106,7 +106,7 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
         List<TimeSeries> result = scaleStage.process(Arrays.asList(inputTimeSeries));
 
         // Assert
-        assertEquals(0.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(0.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessWithNegativeFactor() {
@@ -119,7 +119,7 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
         List<TimeSeries> result = scaleStage.process(Arrays.asList(inputTimeSeries));
 
         // Assert
-        assertEquals(-3.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(-3.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testFromArgs() {
@@ -326,8 +326,8 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
                 assertEquals("Results should have same size", originalResult.size(), readResult.size());
                 assertEquals(
                     "Results should have same scaled value",
-                    originalResult.get(0).getSamples().get(0).getValue(),
-                    readResult.get(0).getSamples().get(0).getValue(),
+                    originalResult.get(0).getSamples().getValue(0),
+                    readResult.get(0).getSamples().getValue(0),
                     0.001
                 );
             }
@@ -647,7 +647,7 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
         assertEquals("First stage should return one time series", 1, result1.size());
 
         // Verify first stage scaling: 10.0 * 2.0 = 20.0, 20.0 * 2.0 = 40.0, 30.0 * 2.0 = 60.0
-        List<Sample> scaledSamples1 = result1.get(0).getSamples();
+        List<Sample> scaledSamples1 = result1.get(0).getSamples().toList();
         assertEquals("First sample should be scaled by 2.0", 20.0, scaledSamples1.get(0).getValue(), 0.001);
         assertEquals("Second sample should be scaled by 2.0", 40.0, scaledSamples1.get(1).getValue(), 0.001);
         assertEquals("Third sample should be scaled by 2.0", 60.0, scaledSamples1.get(2).getValue(), 0.001);
@@ -658,7 +658,7 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
         assertEquals("Second stage should return one time series", 1, result2.size());
 
         // Verify second stage scaling: 10.0 * 3.0 = 30.0, 20.0 * 3.0 = 60.0, 30.0 * 3.0 = 90.0
-        List<Sample> scaledSamples2 = result2.get(0).getSamples();
+        List<Sample> scaledSamples2 = result2.get(0).getSamples().toList();
         assertEquals("First sample should be scaled by 3.0", 30.0, scaledSamples2.get(0).getValue(), 0.001);
         assertEquals("Second sample should be scaled by 3.0", 60.0, scaledSamples2.get(1).getValue(), 0.001);
         assertEquals("Third sample should be scaled by 3.0", 90.0, scaledSamples2.get(2).getValue(), 0.001);
@@ -681,7 +681,7 @@ public class ScaleStageTests extends AbstractWireSerializingTestCase<ScaleStage>
         assertEquals("Should return one time series", 1, output.size());
 
         // Verify scaling: 4.0 * 2.5 = 10.0, 8.0 * 2.5 = 20.0
-        List<Sample> scaledSamples = output.get(0).getSamples();
+        List<Sample> scaledSamples = output.get(0).getSamples().toList();
         assertEquals("First sample should be scaled by 2.5", 10.0, scaledSamples.get(0).getValue(), 0.001);
         assertEquals("Second sample should be scaled by 2.5", 20.0, scaledSamples.get(1).getValue(), 0.001);
     }

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/ScaleToSecondsStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/ScaleToSecondsStageTests.java
@@ -79,7 +79,7 @@ public class ScaleToSecondsStageTests extends AbstractWireSerializingTestCase<Sc
             new FloatSample(20000L, 3.0),   // 30 * 0.1 = 3
             new FloatSample(30000L, 4.0)    // 40 * 0.1 = 4
         );
-        assertSamplesEqual("Series1 with 10s step", expectedSamples1, resultSeries1.getSamples());
+        assertSamplesEqual("Series1 with 10s step", expectedSamples1, resultSeries1.getSamples().toList());
 
         // Verify series2: 20s step, scaleFactor = 0.05
         TimeSeries resultSeries2 = findSeriesByLabel(result, "id", "series2");
@@ -88,7 +88,7 @@ public class ScaleToSecondsStageTests extends AbstractWireSerializingTestCase<Sc
             new FloatSample(20000L, 10.0),  // 200 * 0.05 = 10
             new FloatSample(40000L, 15.0)   // 300 * 0.05 = 15
         );
-        assertSamplesEqual("Series2 with 20s step", expectedSamples2, resultSeries2.getSamples());
+        assertSamplesEqual("Series2 with 20s step", expectedSamples2, resultSeries2.getSamples().toList());
 
         // Verify series3: sparse samples with 10s step
         TimeSeries resultSeries3 = findSeriesByLabel(result, "id", "series3");
@@ -96,7 +96,7 @@ public class ScaleToSecondsStageTests extends AbstractWireSerializingTestCase<Sc
             new FloatSample(0L, 5.0),       // 50 * 0.1 = 5
             new FloatSample(20000L, 6.0)    // 60 * 0.1 = 6
         );
-        assertSamplesEqual("Series3 with sparse samples", expectedSamples3, resultSeries3.getSamples());
+        assertSamplesEqual("Series3 with sparse samples", expectedSamples3, resultSeries3.getSamples().toList());
 
         // Verify series4: empty series
         TimeSeries resultSeries4 = findSeriesByLabel(result, "id", "series4");

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/SortStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/SortStageTests.java
@@ -347,9 +347,9 @@ public class SortStageTests extends AbstractWireSerializingTestCase<SortStage> {
         assertTrue(result.contains(series1));
         assertTrue(result.contains(series2));
         assertNull(getAlias(result.get(0)));
-        assertEquals(1.0, result.get(0).getSamples().get(0).getValue(), 0.0);
+        assertEquals(1.0, result.get(0).getSamples().getValue(0), 0.0);
         assertNull(getAlias(result.get(1)));
-        assertEquals(3.0, result.get(1).getSamples().get(0).getValue(), 0.0);
+        assertEquals(3.0, result.get(1).getSamples().getValue(0), 0.0);
     }
 
     public void testProcessSortByNameWithEmptyAlias() {
@@ -934,7 +934,7 @@ public class SortStageTests extends AbstractWireSerializingTestCase<SortStage> {
         // Test CURRENT when all samples are NaN/null - should return 0.0
         // Need 2 series to trigger comparison
         SortStage sortStage = new SortStage(SortByType.CURRENT);
-        List<Sample> samples = Arrays.asList(new FloatSample(1000L, Double.NaN), null, new FloatSample(3000L, Double.NaN));
+        List<Sample> samples = Arrays.asList(new FloatSample(1000L, Double.NaN), new FloatSample(3000L, Double.NaN));
         Labels labels = ByteLabels.fromMap(Map.of("label", "currentnanonly"));
         TimeSeries timeSeriesNanOnly = new TimeSeries(samples, labels, 1000L, 3000L, 1000L, "currentnanonly");
         TimeSeries normalTimeSeries = createLabeledTimeSeries("normal", Arrays.asList(5.0));

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/SubtractStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/SubtractStageTests.java
@@ -64,7 +64,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
                 new FloatSample(3000L, 30.0), // 30 -0
                 new FloatSample(4000L, -4.0)// 0 - 4
             ),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
 
         SubtractStage stageWithKeepNans = new SubtractStage("right_series", true, Collections.emptyList());
@@ -78,7 +78,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
                 new FloatSample(1000L, 9.0),// 10 - 1
                 new FloatSample(2000L, 18.0)// 20 - 2
             ),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
     }
 
@@ -127,7 +127,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
                 new FloatSample(4000L, -400.0), // 0 - 400
                 new FloatSample(7000L, 100.0) // 100 - 0
             ),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
 
         SubtractStage stageWithKeepNans = new SubtractStage("right_series", true, Collections.emptyList());
@@ -138,7 +138,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
         assertSamplesEqual(
             "Multiple Right Series with keepNans = true",
             List.of(new FloatSample(1000L, 20.0), new FloatSample(2000L, 40.0)),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
     }
 
@@ -193,7 +193,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
         assertSamplesEqual(
             "Selective Label Matching with keepNans = false",
             List.of(new FloatSample(1000L, 24.0)),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
     }
 
@@ -227,7 +227,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
         assertSamplesEqual(
             "Selective Multiple Label Matching with keepNans = false",
             List.of(new FloatSample(1000L, 49.0)),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
     }
 
@@ -270,7 +270,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
                 new FloatSample(2000L, 89.0), // 100 - 2 - 9
                 new FloatSample(3000L, 120.0)  // 150 - 3 - 27
             ),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
     }
 
@@ -348,12 +348,12 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
 
         TimeSeries resultSeries = result.get(0);
         assertEquals(1, resultSeries.getSamples().size());
-        assertEquals(20, resultSeries.getSamples().get(0).getValue(), 0.001); // 25 - 5
-        assertEquals(1000L, resultSeries.getSamples().get(0).getTimestamp());
+        assertEquals(20, resultSeries.getSamples().getValue(0), 0.001); // 25 - 5
+        assertEquals(1000L, resultSeries.getSamples().getTimestamp(0));
         resultSeries = result.get(1);
         assertEquals(1, resultSeries.getSamples().size());
-        assertEquals(45, resultSeries.getSamples().get(0).getValue(), 0.001); // 50 - 5
-        assertEquals(1000L, resultSeries.getSamples().get(0).getTimestamp());
+        assertEquals(45, resultSeries.getSamples().getValue(0), 0.001); // 50 - 5
+        assertEquals(1000L, resultSeries.getSamples().getTimestamp(0));
     }
 
     public void testEdgeCases() {
@@ -433,7 +433,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
                 new FloatSample(2000L, -2.0),  // NaN -> 0.0 - 2.0
                 new FloatSample(3000L, 30.0)   // 30.0 - NaN -> 0.0
             ),
-            resultSeries.getSamples()
+            resultSeries.getSamples().toList()
         );
     }
 
@@ -553,7 +553,7 @@ public class SubtractStageTests extends AbstractWireSerializingTestCase<Subtract
             new FloatSample(2000L, -28.0),  // 2 - (20+10)
             new FloatSample(3000L, -42.0)   // 3 - (30+15)
         );
-        assertSamplesEqual("Subtract with merged right series", expectedSamples, resultSeries.getSamples(), 0.001);
+        assertSamplesEqual("Subtract with merged right series", expectedSamples, resultSeries.getSamples().toList(), 0.001);
 
         // Verify labels come from left series
         assertEquals("a", resultSeries.getLabels().get("tag1"));

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/SumStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/SumStageTests.java
@@ -24,8 +24,6 @@ import static org.opensearch.tsdb.lang.m3.stage.StageTestUtils.createTimeSeries;
 import static org.opensearch.tsdb.lang.m3.stage.StageTestUtils.createTimeSeriesWithGaps;
 
 import static org.opensearch.tsdb.lang.m3.stage.StageTestUtils.createMockAggregations;
-import static org.opensearch.tsdb.lang.m3.stage.StageTestUtils.createTimeSeries;
-import static org.opensearch.tsdb.lang.m3.stage.StageTestUtils.createTimeSeriesWithGaps;
 
 public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
 
@@ -51,7 +49,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         // Check that values are summed correctly
         assertEquals(
             List.of(new FloatSample(1000L, 39.0), new FloatSample(2000L, 83.0), new FloatSample(3000L, 127.0)),
-            summed.getSamples()
+            summed.getSamples().toList()
         );
     }
 
@@ -72,7 +70,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
                 new FloatSample(2000L, 60.0), // 20 + 40
                 new FloatSample(3000L, 90.0)  // 30 + 60
             ),
-            apiGroup.getSamples()
+            apiGroup.getSamples().toList()
         );
 
         // Find the service1 group (ts3)
@@ -81,7 +79,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         assertEquals(3, service1Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
-            service1Group.getSamples()
+            service1Group.getSamples().toList()
         );
 
         // Find the service2 group (ts4)
@@ -90,7 +88,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         assertEquals(3, service2Group.getSamples().size());
         assertEquals(
             List.of(new FloatSample(1000L, 3.0), new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)),
-            service2Group.getSamples()
+            service2Group.getSamples().toList()
         );
     }
 
@@ -112,7 +110,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         // Values should be summed across aggregations
         assertEquals(
             List.of(new FloatSample(1000L, 39.0), new FloatSample(2000L, 83.0), new FloatSample(3000L, 127.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -134,7 +132,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         // Values should be summed across aggregations
         assertEquals(
             List.of(new FloatSample(1000L, 39.0), new FloatSample(2000L, 83.0), new FloatSample(3000L, 127.0)),
-            reduced.getSamples()
+            reduced.getSamples().toList()
         );
     }
 
@@ -168,7 +166,10 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         assertEquals(3, reduced.getSamples().size());
 
         // Values should be summed across aggregations
-        assertEquals(List.of(new FloatSample(1000L, 4.0), new FloatSample(2000L, 8.0), new FloatSample(3000L, 12.0)), reduced.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 4.0), new FloatSample(2000L, 8.0), new FloatSample(3000L, 12.0)),
+            reduced.getSamples().toList()
+        );
     }
 
     public void testConstructorWithNullGroupByLabels() {
@@ -226,7 +227,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
                 new FloatSample(20000L, 20.0),  // 20s: only ts1
                 new FloatSample(30000L, 40.0)   // 30s: only ts2
             ),
-            summed.getSamples()
+            summed.getSamples().toList()
         );
     }
 
@@ -251,7 +252,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
                 new FloatSample(20000L, 15.0),  // 20s: only ts1
                 new FloatSample(30000L, 35.0)   // 30s: only ts2
             ),
-            summed.getSamples()
+            summed.getSamples().toList()
         );
     }
 
@@ -278,7 +279,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
                 new FloatSample(2000L, 40.0),  // NaN + 40 = 40
                 new FloatSample(3000L, 30.0)   // 30 + NaN = 30
             ),
-            summed.getSamples()
+            summed.getSamples().toList()
         );
     }
 
@@ -300,7 +301,7 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
                 new FloatSample(1000L, 30.0),  // 10 + 20
                 new FloatSample(3000L, 90.0)   // 30 + 60
             ),
-            summed.getSamples()
+            summed.getSamples().toList()
         );
     }
 
@@ -318,13 +319,13 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         TimeSeries service1 = result.stream().filter(ts -> "service1".equals(ts.getLabels().get("service"))).findFirst().orElse(null);
         assertNotNull(service1);
         assertEquals(2, service1.getSamples().size()); // timestamps 1000 and 3000 only
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(3000L, 25.0)), service1.getSamples());
+        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(3000L, 25.0)), service1.getSamples().toList());
 
         // Find service2 group
         TimeSeries service2 = result.stream().filter(ts -> "service2".equals(ts.getLabels().get("service"))).findFirst().orElse(null);
         assertNotNull(service2);
         assertEquals(2, service2.getSamples().size()); // timestamps 2000 and 3000 only
-        assertEquals(List.of(new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)), service2.getSamples());
+        assertEquals(List.of(new FloatSample(2000L, 6.0), new FloatSample(3000L, 9.0)), service2.getSamples().toList());
     }
 
     public void testProcessEmptyInput() {
@@ -349,7 +350,10 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         TimeSeries summed = result.get(0);
         assertEquals("service1", summed.getLabels().get("service"));
         assertEquals(3, summed.getSamples().size());
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)), summed.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
+            summed.getSamples().toList()
+        );
     }
 
     public void testProcessGroupWithMultipleTimeSeries() {
@@ -361,7 +365,10 @@ public class SumStageTests extends AbstractWireSerializingTestCase<SumStage> {
         TimeSeries summed = result.get(0);
         assertEquals("service1", summed.getLabels().get("service"));
         assertEquals(3, summed.getSamples().size());
-        assertEquals(List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)), summed.getSamples());
+        assertEquals(
+            List.of(new FloatSample(1000L, 5.0), new FloatSample(2000L, 15.0), new FloatSample(3000L, 25.0)),
+            summed.getSamples().toList()
+        );
     }
 
     // Comprehensive test data - all tests use this same dataset

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/SummarizeStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/SummarizeStageTests.java
@@ -111,7 +111,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 210.0),
             new FloatSample(900L, 190.0)
         );
-        assertSamplesEqual("Sum Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Sum Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: [10], [30+50], [70], [90] -> 10, 80, 70, 90
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -121,7 +121,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("Sum Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Sum Sparse", expectedSparse, sparseResult.getSamples().toList());
 
         // Empty result: no samples
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");
@@ -142,7 +142,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 95.0)
         );
-        assertSamplesEqual("Avg Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Avg Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: avg([10])=10, avg([30,50])=40, avg([70])=70, avg([90])=90
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -152,7 +152,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("Avg Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Avg Sparse", expectedSparse, sparseResult.getSamples().toList());
     }
 
     public void testSummarizeMax() {
@@ -169,7 +169,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 80.0),
             new FloatSample(900L, 100.0)
         );
-        assertSamplesEqual("Max Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Max Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: max([10])=10, max([30,50])=50, max([70])=70, max([90])=90
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -179,7 +179,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("Max Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Max Sparse", expectedSparse, sparseResult.getSamples().toList());
     }
 
     public void testSummarizeMin() {
@@ -196,7 +196,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 60.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("Min Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Min Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: min([10])=10, min([30,50])=30, min([70])=70, min([90])=90
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -206,7 +206,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("Min Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Min Sparse", expectedSparse, sparseResult.getSamples().toList());
     }
 
     public void testSummarizeLast() {
@@ -223,7 +223,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 80.0),
             new FloatSample(900L, 100.0)
         );
-        assertSamplesEqual("Last Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Last Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse result: last([10])=10, last([30,50])=50, last([70])=70, last([90])=90
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
@@ -233,7 +233,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("Last Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Last Sparse", expectedSparse, sparseResult.getSamples().toList());
     }
 
     public void testSummarizeP50() {
@@ -250,7 +250,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 70.0),
             new FloatSample(900L, 90.0)
         );
-        assertSamplesEqual("P50 Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("P50 Dense", expectedDense, denseResult.getSamples().toList());
     }
 
     public void testSummarizeStdDev() {
@@ -267,7 +267,7 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(600L, 10.0),
             new FloatSample(900L, 7.0710678118654755)
         );
-        assertSamplesEqual("StdDev Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("StdDev Dense", expectedDense, denseResult.getSamples().toList());
     }
 
     public void testSummarizeAlignToFrom() {
@@ -286,12 +286,12 @@ public class SummarizeStageTests extends AbstractWireSerializingTestCase<Summari
             new FloatSample(700L, 240.0),
             new FloatSample(1000L, 100.0)
         );
-        assertSamplesEqual("AlignToFrom Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("AlignToFrom Dense", expectedDense, denseResult.getSamples().toList());
 
         // Sparse: [10,30] -> 40, [50] -> 50, [70,90] -> 160, [] -> no bucket
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
         List<Sample> expectedSparse = List.of(new FloatSample(100L, 40.0), new FloatSample(400L, 50.0), new FloatSample(700L, 160.0));
-        assertSamplesEqual("AlignToFrom Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("AlignToFrom Sparse", expectedSparse, sparseResult.getSamples().toList());
     }
 
     public void testSummarizeIntervalSmallerThanResolution() {

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/SustainStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/SustainStageTests.java
@@ -125,7 +125,7 @@ public class SustainStageTests extends AbstractWireSerializingTestCase<SustainSt
             new FloatSample(6000L, 6.0),
             new FloatSample(7000L, 7.0)
         );
-        assertSamplesEqual("Long sustained series", expectedLongSustained, longSustainedResult.getSamples());
+        assertSamplesEqual("Long sustained series", expectedLongSustained, longSustainedResult.getSamples().toList());
 
         // Short result: [] - no samples meet requirement
         TimeSeries shortResult = findSeriesByLabel(result, "type", "short");
@@ -138,12 +138,12 @@ public class SustainStageTests extends AbstractWireSerializingTestCase<SustainSt
         // NaN after result: [3] - sample at 3000 has 3-sample prefix [1,2,3]
         TimeSeries nanAfterResult = findSeriesByLabel(result, "type", "nan_after");
         List<Sample> expectedNanAfter = List.of(new FloatSample(3000L, 3.0));
-        assertSamplesEqual("NaN after series", expectedNanAfter, nanAfterResult.getSamples());
+        assertSamplesEqual("NaN after series", expectedNanAfter, nanAfterResult.getSamples().toList());
 
         // Multi-window result: [3, 7] - two sustained windows meet requirement
         TimeSeries multiWindowResult = findSeriesByLabel(result, "type", "multi_window");
         List<Sample> expectedMultiWindow = List.of(new FloatSample(3000L, 3.0), new FloatSample(7000L, 7.0));
-        assertSamplesEqual("Multi-window series", expectedMultiWindow, multiWindowResult.getSamples());
+        assertSamplesEqual("Multi-window series", expectedMultiWindow, multiWindowResult.getSamples().toList());
 
         // Empty result: no samples
         TimeSeries emptyResult = findSeriesByLabel(result, "type", "empty");

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/TimeshiftStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/TimeshiftStageTests.java
@@ -80,12 +80,12 @@ public class TimeshiftStageTests extends AbstractWireSerializingTestCase<Timeshi
         assertEquals(1, result.size());
         TimeSeries shiftedTimeSeries = result.get(0);
         assertEquals(3, shiftedTimeSeries.getSamples().size());
-        assertEquals(3601000L, shiftedTimeSeries.getSamples().get(0).getTimestamp());
-        assertEquals(3602000L, shiftedTimeSeries.getSamples().get(1).getTimestamp());
-        assertEquals(3603000L, shiftedTimeSeries.getSamples().get(2).getTimestamp());
-        assertEquals(10.0, shiftedTimeSeries.getSamples().get(0).getValue(), 0.001);
-        assertEquals(20.0, shiftedTimeSeries.getSamples().get(1).getValue(), 0.001);
-        assertEquals(30.0, shiftedTimeSeries.getSamples().get(2).getValue(), 0.001);
+        assertEquals(3601000L, shiftedTimeSeries.getSamples().getTimestamp(0));
+        assertEquals(3602000L, shiftedTimeSeries.getSamples().getTimestamp(1));
+        assertEquals(3603000L, shiftedTimeSeries.getSamples().getTimestamp(2));
+        assertEquals(10.0, shiftedTimeSeries.getSamples().getValue(0), 0.001);
+        assertEquals(20.0, shiftedTimeSeries.getSamples().getValue(1), 0.001);
+        assertEquals(30.0, shiftedTimeSeries.getSamples().getValue(2), 0.001);
         assertEquals(labels, shiftedTimeSeries.getLabels());
         assertEquals("test-series", shiftedTimeSeries.getAlias());
     }
@@ -104,10 +104,10 @@ public class TimeshiftStageTests extends AbstractWireSerializingTestCase<Timeshi
 
         // Assert
         assertEquals(2, result.size());
-        assertEquals(1801000L, result.get(0).getSamples().get(0).getTimestamp()); // 1000 + 30*60*1000
-        assertEquals(1802000L, result.get(1).getSamples().get(0).getTimestamp()); // 2000 + 30*60*1000
-        assertEquals(5.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(10.0, result.get(1).getSamples().get(0).getValue(), 0.001);
+        assertEquals(1801000L, result.get(0).getSamples().getTimestamp(0)); // 1000 + 30*60*1000
+        assertEquals(1802000L, result.get(1).getSamples().getTimestamp(0)); // 2000 + 30*60*1000
+        assertEquals(5.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(10.0, result.get(1).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessWithEmptyInput() {
@@ -154,8 +154,8 @@ public class TimeshiftStageTests extends AbstractWireSerializingTestCase<Timeshi
 
         // Assert
         assertEquals(1, result.size());
-        assertEquals(1100L, result.get(0).getSamples().get(0).getTimestamp()); // 1000 + 100
-        assertEquals(10.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(1100L, result.get(0).getSamples().getTimestamp(0)); // 1000 + 100
+        assertEquals(10.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessWithZeroShift() {
@@ -171,10 +171,10 @@ public class TimeshiftStageTests extends AbstractWireSerializingTestCase<Timeshi
         // Assert
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getSamples().size());
-        assertEquals(1000L, result.get(0).getSamples().get(0).getTimestamp());
-        assertEquals(2000L, result.get(0).getSamples().get(1).getTimestamp());
-        assertEquals(10.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(20.0, result.get(0).getSamples().get(1).getValue(), 0.001);
+        assertEquals(1000L, result.get(0).getSamples().getTimestamp(0));
+        assertEquals(2000L, result.get(0).getSamples().getTimestamp(1));
+        assertEquals(10.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(20.0, result.get(0).getSamples().getValue(1), 0.001);
     }
 
     // ========== FromArgs Method Tests ==========

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/TransformNullStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/TransformNullStageTests.java
@@ -49,7 +49,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
 
         // All values should be filled with 10.0
         List<Sample> expectedSamples = List.of(new FloatSample(10L, 10.0), new FloatSample(20L, 10.0), new FloatSample(30L, 10.0));
-        assertSamplesEqual("All null values test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("All null values test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -83,7 +83,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
             new FloatSample(40L, 5.0),  // filled
             new FloatSample(50L, 5.0)   // filled
         );
-        assertSamplesEqual("Mixed values test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Mixed values test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -111,7 +111,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
             new FloatSample(30L, 0.0),   // filled
             new FloatSample(40L, 0.0)    // filled
         );
-        assertSamplesEqual("Default fill value test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Default fill value test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -145,7 +145,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
             new FloatSample(40L, 7.0),  // NaN replaced with fill value
             new FloatSample(50L, 5.0)   // original
         );
-        assertSamplesEqual("NaN values test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("NaN values test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -178,7 +178,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
             new FloatSample(40L, 4.0),  // original
             new FloatSample(50L, 9.0)   // missing, filled
         );
-        assertSamplesEqual("Mixed NaN and missing values test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("Mixed NaN and missing values test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -204,7 +204,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
 
         // All NaN values should be replaced with 3.0
         List<Sample> expectedSamples = List.of(new FloatSample(10L, 3.0), new FloatSample(20L, 3.0), new FloatSample(30L, 3.0));
-        assertSamplesEqual("All NaN values test", expectedSamples, resultSeries.getSamples());
+        assertSamplesEqual("All NaN values test", expectedSamples, resultSeries.getSamples().toList());
     }
 
     /**
@@ -241,14 +241,14 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
             new FloatSample(10L, 2.0),  // filled
             new FloatSample(20L, 5.0)   // original
         );
-        assertSamplesEqual("First time series samples", expectedSamples1, result.get(0).getSamples());
+        assertSamplesEqual("First time series samples", expectedSamples1, result.get(0).getSamples().toList());
 
         // Second time series: expected [10.0 at 100L, 2.0 at 110L]
         List<Sample> expectedSamples2 = List.of(
             new FloatSample(100L, 10.0), // original
             new FloatSample(110L, 2.0)   // filled
         );
-        assertSamplesEqual("Second time series samples", expectedSamples2, result.get(1).getSamples());
+        assertSamplesEqual("Second time series samples", expectedSamples2, result.get(1).getSamples().toList());
     }
 
     /**
@@ -288,7 +288,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
         List<TimeSeries> result = stage.process(List.of(timeSeries));
 
         List<Sample> expectedSamples = List.of(new FloatSample(10L, 3.5));
-        assertSamplesEqual("fromArgs test", expectedSamples, result.get(0).getSamples());
+        assertSamplesEqual("fromArgs test", expectedSamples, result.get(0).getSamples().toList());
     }
 
     /**
@@ -306,7 +306,7 @@ public class TransformNullStageTests extends AbstractWireSerializingTestCase<Tra
         List<TimeSeries> result = stage.process(List.of(timeSeries));
 
         List<Sample> expectedSamples = List.of(new FloatSample(10L, 0.0));
-        assertSamplesEqual("fromArgs with default value test", expectedSamples, result.get(0).getSamples());
+        assertSamplesEqual("fromArgs with default value test", expectedSamples, result.get(0).getSamples().toList());
     }
 
     /**

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/TruncateStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/TruncateStageTests.java
@@ -95,14 +95,14 @@ public class TruncateStageTests extends AbstractWireSerializingTestCase<Truncate
         // Dense: keep samples in [20, 50) - excludes 50
         TimeSeries denseResult = findSeriesByLabel(result, "type", "dense");
         List<Sample> expectedDense = List.of(new FloatSample(20L, 3.0), new FloatSample(30L, 4.0), new FloatSample(40L, 5.0));
-        assertSamplesEqual("Both Dense", expectedDense, denseResult.getSamples());
+        assertSamplesEqual("Both Dense", expectedDense, denseResult.getSamples().toList());
         assertEquals("Truncated minTimestamp should be 20", 20L, denseResult.getMinTimestamp());
         assertEquals("Truncated maxTimestamp should be 40 (largest aligned < 50)", 40L, denseResult.getMaxTimestamp());
 
         // Sparse: keep samples in [20, 50) (20 and 50 missing, only 30 and 40)
         TimeSeries sparseResult = findSeriesByLabel(result, "type", "sparse");
         List<Sample> expectedSparse = List.of(new FloatSample(30L, 4.0), new FloatSample(40L, 5.0));
-        assertSamplesEqual("Both Sparse", expectedSparse, sparseResult.getSamples());
+        assertSamplesEqual("Both Sparse", expectedSparse, sparseResult.getSamples().toList());
         assertEquals("Truncated minTimestamp should be 20", 20L, sparseResult.getMinTimestamp());
         assertEquals("Truncated maxTimestamp should be 40 (largest aligned < 50)", 40L, sparseResult.getMaxTimestamp());
 

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/UnaryFallbackSeriesStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/UnaryFallbackSeriesStageTests.java
@@ -43,7 +43,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
 
         assertEquals(1, result.size());
         assertEquals("input", result.get(0).getLabels().get("name"));
-        assertSamplesEqual("Input samples should match", inputSamples, result.get(0).getSamples());
+        assertSamplesEqual("Input samples should match", inputSamples, result.get(0).getSamples().toList());
     }
 
     /**
@@ -77,7 +77,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
             new FloatSample(10L, fallbackValue),
             new FloatSample(20L, fallbackValue)
         );
-        assertSamplesEqual("Constant series samples should match", expectedSamples, constantSeries.getSamples());
+        assertSamplesEqual("Constant series samples should match", expectedSamples, constantSeries.getSamples().toList());
     }
 
     /**
@@ -114,7 +114,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
 
         assertEquals(1, result.size());
         TimeSeries constantSeries = result.get(0);
-        assertEquals(-5.0, ((FloatSample) constantSeries.getSamples().get(0)).getValue(), 0.001);
+        assertEquals(-5.0, constantSeries.getSamples().getValue(0), 0.001);
     }
 
     /**
@@ -127,7 +127,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
 
         assertEquals(1, result.size());
         TimeSeries constantSeries = result.get(0);
-        assertEquals(0.0, ((FloatSample) constantSeries.getSamples().get(0)).getValue(), 0.001);
+        assertEquals(0.0, constantSeries.getSamples().getValue(0), 0.001);
         // Verify alias formatting: 0 -> "0.000"
         assertEquals("0.000", constantSeries.getAlias());
     }
@@ -175,7 +175,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
         // maxTimestamp in TimeSeries is the last sample timestamp (15), not the exclusive upper bound (30)
         assertEquals(15L, constantSeries.getMaxTimestamp());
         assertEquals(15L, constantSeries.getStep());
-        assertEquals(3.0, ((FloatSample) constantSeries.getSamples().get(0)).getValue(), 0.001);
+        assertEquals(3.0, constantSeries.getSamples().getValue(0), 0.001);
     }
 
     /**
@@ -319,7 +319,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
         // Verify by checking the stage processes correctly
         List<TimeSeries> result = ((FallbackSeriesUnaryStage) stage).process(List.of());
         assertEquals(1, result.size());
-        assertEquals(1.0, ((FloatSample) result.get(0).getSamples().get(0)).getValue(), 0.001);
+        assertEquals(1.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     @Override
@@ -342,7 +342,7 @@ public class UnaryFallbackSeriesStageTests extends AbstractWireSerializingTestCa
         // Extract values by processing an empty input to create a constant series
         List<TimeSeries> result = instance.process(List.of());
         TimeSeries constantSeries = result.get(0);
-        double fallbackValue = ((FloatSample) constantSeries.getSamples().get(0)).getValue();
+        double fallbackValue = constantSeries.getSamples().getValue(0);
 
         return new FallbackSeriesUnaryStage(
             fallbackValue + 1.0,

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/ValueFilterStageTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/ValueFilterStageTests.java
@@ -73,7 +73,7 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertEquals(10.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(10.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessNeOperator() {
@@ -87,8 +87,8 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getSamples().size());
-        assertEquals(5.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(15.0, result.get(0).getSamples().get(1).getValue(), 0.001);
+        assertEquals(5.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(15.0, result.get(0).getSamples().getValue(1), 0.001);
     }
 
     public void testProcessGtOperator() {
@@ -102,7 +102,7 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertEquals(15.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(15.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessGeOperator() {
@@ -116,8 +116,8 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getSamples().size());
-        assertEquals(10.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(15.0, result.get(0).getSamples().get(1).getValue(), 0.001);
+        assertEquals(10.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(15.0, result.get(0).getSamples().getValue(1), 0.001);
     }
 
     public void testProcessLtOperator() {
@@ -131,7 +131,7 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertEquals(5.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(5.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessLeOperator() {
@@ -145,8 +145,8 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(2, result.get(0).getSamples().size());
-        assertEquals(5.0, result.get(0).getSamples().get(0).getValue(), 0.001);
-        assertEquals(10.0, result.get(0).getSamples().get(1).getValue(), 0.001);
+        assertEquals(5.0, result.get(0).getSamples().getValue(0), 0.001);
+        assertEquals(10.0, result.get(0).getSamples().getValue(1), 0.001);
     }
 
     public void testProcessWithNaNValues() {
@@ -167,7 +167,7 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertEquals(10.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(10.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     public void testProcessWithNullSamples() {
@@ -184,7 +184,7 @@ public class ValueFilterStageTests extends AbstractWireSerializingTestCase<Value
         // Assert
         assertEquals(1, result.size());
         assertEquals(1, result.get(0).getSamples().size());
-        assertEquals(10.0, result.get(0).getSamples().get(0).getValue(), 0.001);
+        assertEquals(10.0, result.get(0).getSamples().getValue(0), 0.001);
     }
 
     // ========== Serialization Tests ==========

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesSerializationTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesSerializationTests.java
@@ -123,8 +123,8 @@ public class InternalTimeSeriesSerializationTests extends AbstractWireTestCase<I
 
                 // Verify mixed sample types are preserved
                 for (int i = 0; i < origSeries.getSamples().size(); i++) {
-                    Sample origSample = origSeries.getSamples().get(i);
-                    Sample deserSample = deserSeries.getSamples().get(i);
+                    Sample origSample = origSeries.getSamples().getSample(i);
+                    Sample deserSample = deserSeries.getSamples().getSample(i);
 
                     assertEquals(origSample.getClass(), deserSample.getClass());
                     assertEquals(origSample.getTimestamp(), deserSample.getTimestamp());

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesNormalizerTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesNormalizerTests.java
@@ -178,9 +178,9 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
 
         // === EXECUTE TESTS FOR ALL CONSOLIDATION METHODS ===
 
-        assertSamplesEqual("Series A SUM consolidation", expectedA_SUM, resultSum.get(0).getSamples());
-        assertSamplesEqual("Series B SUM consolidation", expectedB_SUM, resultSum.get(1).getSamples());
-        assertSamplesEqual("Series C SUM consolidation", expectedC_SUM, resultSum.get(2).getSamples());
+        assertSamplesEqual("Series A SUM consolidation", expectedA_SUM, resultSum.get(0).getSamples().toList());
+        assertSamplesEqual("Series B SUM consolidation", expectedB_SUM, resultSum.get(1).getSamples().toList());
+        assertSamplesEqual("Series C SUM consolidation", expectedC_SUM, resultSum.get(2).getSamples().toList());
 
         // Test AVG consolidation
         List<TimeSeries> resultAvg = TimeSeriesNormalizer.normalize(
@@ -188,9 +188,9 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
             TimeSeriesNormalizer.StepSizeStrategy.LCM,
             TimeSeriesNormalizer.ConsolidationStrategy.AVG
         );
-        assertSamplesEqual("Series A AVG consolidation", expectedA_AVG, resultAvg.get(0).getSamples());
-        assertSamplesEqual("Series B AVG consolidation", expectedB_AVG, resultAvg.get(1).getSamples());
-        assertSamplesEqual("Series C AVG consolidation", expectedC_AVG, resultAvg.get(2).getSamples());
+        assertSamplesEqual("Series A AVG consolidation", expectedA_AVG, resultAvg.get(0).getSamples().toList());
+        assertSamplesEqual("Series B AVG consolidation", expectedB_AVG, resultAvg.get(1).getSamples().toList());
+        assertSamplesEqual("Series C AVG consolidation", expectedC_AVG, resultAvg.get(2).getSamples().toList());
 
         // Test MAX consolidation
         List<TimeSeries> resultMax = TimeSeriesNormalizer.normalize(
@@ -198,9 +198,9 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
             TimeSeriesNormalizer.StepSizeStrategy.LCM,
             TimeSeriesNormalizer.ConsolidationStrategy.MAX
         );
-        assertSamplesEqual("Series A MAX consolidation", expectedA_MAX, resultMax.get(0).getSamples());
-        assertSamplesEqual("Series B MAX consolidation", expectedB_MAX, resultMax.get(1).getSamples());
-        assertSamplesEqual("Series C MAX consolidation", expectedC_MAX, resultMax.get(2).getSamples());
+        assertSamplesEqual("Series A MAX consolidation", expectedA_MAX, resultMax.get(0).getSamples().toList());
+        assertSamplesEqual("Series B MAX consolidation", expectedB_MAX, resultMax.get(1).getSamples().toList());
+        assertSamplesEqual("Series C MAX consolidation", expectedC_MAX, resultMax.get(2).getSamples().toList());
 
         // Test MIN consolidation
         List<TimeSeries> resultMin = TimeSeriesNormalizer.normalize(
@@ -208,9 +208,9 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
             TimeSeriesNormalizer.StepSizeStrategy.LCM,
             TimeSeriesNormalizer.ConsolidationStrategy.MIN
         );
-        assertSamplesEqual("Series A MIN consolidation", expectedA_MIN, resultMin.get(0).getSamples());
-        assertSamplesEqual("Series B MIN consolidation", expectedB_MIN, resultMin.get(1).getSamples());
-        assertSamplesEqual("Series C MIN consolidation", expectedC_MIN, resultMin.get(2).getSamples());
+        assertSamplesEqual("Series A MIN consolidation", expectedA_MIN, resultMin.get(0).getSamples().toList());
+        assertSamplesEqual("Series B MIN consolidation", expectedB_MIN, resultMin.get(1).getSamples().toList());
+        assertSamplesEqual("Series C MIN consolidation", expectedC_MIN, resultMin.get(2).getSamples().toList());
 
         // Test LAST consolidation
         List<TimeSeries> resultLast = TimeSeriesNormalizer.normalize(
@@ -218,9 +218,9 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
             TimeSeriesNormalizer.StepSizeStrategy.LCM,
             TimeSeriesNormalizer.ConsolidationStrategy.LAST
         );
-        assertSamplesEqual("Series A LAST consolidation", expectedA_LAST, resultLast.get(0).getSamples());
-        assertSamplesEqual("Series B LAST consolidation", expectedB_LAST, resultLast.get(1).getSamples());
-        assertSamplesEqual("Series C LAST consolidation", expectedC_LAST, resultLast.get(2).getSamples());
+        assertSamplesEqual("Series A LAST consolidation", expectedA_LAST, resultLast.get(0).getSamples().toList());
+        assertSamplesEqual("Series B LAST consolidation", expectedB_LAST, resultLast.get(1).getSamples().toList());
+        assertSamplesEqual("Series C LAST consolidation", expectedC_LAST, resultLast.get(2).getSamples().toList());
     }
 
     public void testNormalize_SkipsNaNValues() {
@@ -249,8 +249,8 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
         // Bucket [0, 10000): samples at 0(NaN) and 5000(20), only 20 counts = 20
         // Bucket [10000, 20000): samples at 10000(30), only 30 counts = 30
         assertEquals(2, normalized.getSamples().size());
-        assertEquals(20.0f, normalized.getSamples().get(0).getValue(), 0.001f);
-        assertEquals(30.0f, normalized.getSamples().get(1).getValue(), 0.001f);
+        assertEquals(20.0f, normalized.getSamples().getValue(0), 0.001f);
+        assertEquals(30.0f, normalized.getSamples().getValue(1), 0.001f);
     }
 
     public void testNormalize_EmptyBucketSkipped() {
@@ -268,10 +268,10 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
         // Bucket [0, 30000): contains sample at 0L (10.0)
         // Bucket [30000, 60000): contains sample at 30000L (30.0)
         assertEquals(2, normalized.getSamples().size());
-        assertEquals(0L, normalized.getSamples().get(0).getTimestamp());
-        assertEquals(10.0f, normalized.getSamples().get(0).getValue(), 0.001f);
-        assertEquals(30000L, normalized.getSamples().get(1).getTimestamp());
-        assertEquals(30.0f, normalized.getSamples().get(1).getValue(), 0.001f);
+        assertEquals(0L, normalized.getSamples().getTimestamp(0));
+        assertEquals(10.0f, normalized.getSamples().getValue(0), 0.001f);
+        assertEquals(30000L, normalized.getSamples().getTimestamp(1));
+        assertEquals(30.0f, normalized.getSamples().getValue(1), 0.001f);
     }
 
     public void testNormalize_AcceptsEmptyList() {
@@ -340,27 +340,27 @@ public class TimeSeriesNormalizerTests extends OpenSearchTestCase {
             new FloatSample(0L, 30.0f),      // sum(10, 20) = 30
             new FloatSample(10000L, 30.0f)   // sum(30) = 30
         );
-        assertSamplesEqual("Counter series TYPE_AWARE", expectedCounter, result.get(0).getSamples(), 0.001f);
+        assertSamplesEqual("Counter series TYPE_AWARE", expectedCounter, result.get(0).getSamples().toList(), 0.001f);
 
         // Counts series should use SUM: bucket [0, 10000) contains samples 15, 25 → sum = 40
         List<Sample> expectedCounts = List.of(
             new FloatSample(0L, 40.0f),      // sum(15, 25) = 40
             new FloatSample(10000L, 35.0f)   // sum(35) = 35
         );
-        assertSamplesEqual("Counts series TYPE_AWARE", expectedCounts, result.get(1).getSamples(), 0.001f);
+        assertSamplesEqual("Counts series TYPE_AWARE", expectedCounts, result.get(1).getSamples().toList(), 0.001f);
 
         // No type series should use AVG: bucket [0, 10000) contains samples 5, 10 → avg = 7.5
         List<Sample> expectedNoType = List.of(
             new FloatSample(0L, 7.5f),      // avg(5, 10) = 7.5
             new FloatSample(10000L, 15.0f)   // avg(15) = 15
         );
-        assertSamplesEqual("No type series TYPE_AWARE", expectedNoType, result.get(2).getSamples(), 0.001f);
+        assertSamplesEqual("No type series TYPE_AWARE", expectedNoType, result.get(2).getSamples().toList(), 0.001f);
 
         // Trigger series (no type label) should use AVG: bucket [0, 10000) contains sample 100 → avg = 100
         List<Sample> expectedTrigger = List.of(
             new FloatSample(0L, 100.0f),    // avg(100) = 100
             new FloatSample(10000L, 200.0f) // avg(200) = 200
         );
-        assertSamplesEqual("Trigger series TYPE_AWARE", expectedTrigger, result.get(3).getSamples(), 0.001f);
+        assertSamplesEqual("Trigger series TYPE_AWARE", expectedTrigger, result.get(3).getSamples().toList(), 0.001f);
     }
 }

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesTests.java
@@ -34,7 +34,7 @@ public class TimeSeriesTests extends OpenSearchTestCase {
         TimeSeries timeSeries = new TimeSeries(samples, labels, minTimestamp, maxTimestamp, step, alias);
 
         // Assert
-        assertEquals(samples, timeSeries.getSamples());
+        assertEquals(samples, timeSeries.getSamples().toList());
         assertEquals(labels, timeSeries.getLabels());
         assertEquals(minTimestamp, timeSeries.getMinTimestamp());
         assertEquals(maxTimestamp, timeSeries.getMaxTimestamp());
@@ -202,7 +202,7 @@ public class TimeSeriesTests extends OpenSearchTestCase {
         TimeSeries timeSeries = new TimeSeries(samples, labels, 1000L, 2000L, 1000L, null);
 
         // Assert
-        assertEquals(samples, timeSeries.getSamples());
+        assertEquals(samples, timeSeries.getSamples().toList());
         assertEquals(labels, timeSeries.getLabels());
         assertEquals(1000L, timeSeries.getMinTimestamp());
         assertEquals(2000L, timeSeries.getMaxTimestamp());
@@ -218,10 +218,10 @@ public class TimeSeriesTests extends OpenSearchTestCase {
         TimeSeries timeSeries = new TimeSeries(samples, labels, 1000L, 2000L, 1000L, null);
 
         // Assert
-        assertEquals(samples, timeSeries.getSamples());
+        assertEquals(samples, timeSeries.getSamples().toList());
         assertEquals(2, timeSeries.getSamples().size());
-        assertTrue(timeSeries.getSamples().get(0) instanceof FloatSample);
-        assertTrue(timeSeries.getSamples().get(1) instanceof SumCountSample);
+        assertTrue(timeSeries.getSamples().getSample(0) instanceof FloatSample);
+        assertTrue(timeSeries.getSamples().getSample(1) instanceof SumCountSample);
     }
 
     public void testWithEmptySamples() {
@@ -233,7 +233,7 @@ public class TimeSeriesTests extends OpenSearchTestCase {
         TimeSeries timeSeries = new TimeSeries(emptySamples, labels, 0L, 0L, 0L, null);
 
         // Assert
-        assertEquals(emptySamples, timeSeries.getSamples());
+        assertEquals(emptySamples, timeSeries.getSamples().toList());
         assertTrue(timeSeries.getSamples().isEmpty());
     }
 

--- a/src/test/java/org/opensearch/tsdb/query/utils/SampleMergerTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/utils/SampleMergerTests.java
@@ -10,6 +10,7 @@ package org.opensearch.tsdb.query.utils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +30,7 @@ public class SampleMergerTests extends OpenSearchTestCase {
 
         List<Sample> samples2 = Arrays.asList(new FloatSample(1500L, 15.0), new FloatSample(2500L, 25.0), new FloatSample(3500L, 35.0));
 
-        List<Sample> result = merger.merge(samples1, samples2, true);
+        List<Sample> result = merger.merge(SampleList.fromList(samples1), SampleList.fromList(samples2), true).toList();
 
         assertEquals("Should have 6 samples", 6, result.size());
         assertThat("First sample should be from samples1", result.get(0).getTimestamp(), equalTo(1000L));
@@ -47,7 +48,7 @@ public class SampleMergerTests extends OpenSearchTestCase {
             new FloatSample(2000L, 25.0)  // Duplicate timestamp
         );
 
-        List<Sample> result = merger.merge(samples1, samples2, true);
+        List<Sample> result = merger.merge(SampleList.fromList(samples1), SampleList.fromList(samples2), true).toList();
 
         assertEquals("Should have 2 samples (duplicates merged)", 2, result.size());
         assertThat("First sample should be from samples2 (newer)", result.get(0).getTimestamp(), equalTo(1000L));
@@ -66,7 +67,7 @@ public class SampleMergerTests extends OpenSearchTestCase {
             new FloatSample(2000L, 25.0)  // Duplicate timestamp
         );
 
-        List<Sample> result = merger.merge(samples1, samples2, true);
+        List<Sample> result = merger.merge(SampleList.fromList(samples1), SampleList.fromList(samples2), true).toList();
 
         assertEquals("Should have 2 samples (duplicates merged)", 2, result.size());
         assertThat("First sample should be merged", result.get(0).getTimestamp(), equalTo(1000L));
@@ -82,7 +83,7 @@ public class SampleMergerTests extends OpenSearchTestCase {
 
         List<Sample> samples2 = Arrays.asList(new FloatSample(2500L, 25.0), new FloatSample(1500L, 15.0), new FloatSample(3500L, 35.0));
 
-        List<Sample> result = merger.merge(samples1, samples2, false);
+        List<Sample> result = merger.merge(SampleList.fromList(samples1), SampleList.fromList(samples2), false).toList();
 
         assertEquals("Should have 6 samples", 6, result.size());
         // Verify result is sorted
@@ -99,16 +100,16 @@ public class SampleMergerTests extends OpenSearchTestCase {
         List<Sample> samples = Arrays.asList(new FloatSample(1000L, 10.0));
 
         // Both empty
-        List<Sample> result1 = merger.merge(empty1, empty2, true);
+        List<Sample> result1 = merger.merge(SampleList.fromList(empty1), SampleList.fromList(empty2), true).toList();
         assertTrue("Empty merge should return empty list", result1.isEmpty());
 
         // First empty
-        List<Sample> result2 = merger.merge(empty1, samples, true);
+        List<Sample> result2 = merger.merge(SampleList.fromList(empty1), SampleList.fromList(samples), true).toList();
         assertEquals("Should return second list", samples.size(), result2.size());
         assertThat("Should return second list", result2.get(0).getTimestamp(), equalTo(1000L));
 
         // Second empty
-        List<Sample> result3 = merger.merge(samples, empty2, true);
+        List<Sample> result3 = merger.merge(SampleList.fromList(samples), SampleList.fromList(empty2), true).toList();
         assertEquals("Should return first list", samples.size(), result3.size());
         assertThat("Should return first list", result3.get(0).getTimestamp(), equalTo(1000L));
     }
@@ -120,7 +121,7 @@ public class SampleMergerTests extends OpenSearchTestCase {
         List<Sample> samples1 = Arrays.asList(new FloatSample(1000L, 10.0));
         List<Sample> samples2 = Arrays.asList(new FloatSample(1000L, 20.0));
 
-        List<Sample> result = merger.merge(samples1, samples2, true);
+        List<Sample> result = merger.merge(SampleList.fromList(samples1), SampleList.fromList(samples2), true).toList();
 
         assertEquals("Should have 1 sample (duplicate merged)", 1, result.size());
         assertThat("Should use ANY_WINS policy", ((FloatSample) result.get(0)).getValue(), equalTo(20.0));
@@ -133,7 +134,7 @@ public class SampleMergerTests extends OpenSearchTestCase {
         List<Sample> samples1 = Arrays.asList(new FloatSample(1000L, 10.0));
         List<Sample> samples2 = Arrays.asList(new FloatSample(1000L, 20.0));
 
-        List<Sample> result = merger.merge(samples1, samples2, true);
+        List<Sample> result = merger.merge(SampleList.fromList(samples1), SampleList.fromList(samples2), true).toList();
 
         assertEquals("Should have 1 sample", 1, result.size());
         // Should sum the values since both are FloatSample

--- a/src/test/java/org/opensearch/tsdb/query/utils/TimeSeriesOutputMapperTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/utils/TimeSeriesOutputMapperTests.java
@@ -13,6 +13,7 @@ import org.opensearch.tsdb.core.model.ByteLabels;
 import org.opensearch.tsdb.core.model.FloatSample;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.InternalTimeSeries;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.utils.TimeSeriesOutputMapper.TimeSeriesResult;
@@ -168,7 +169,7 @@ public class TimeSeriesOutputMapperTests extends OpenSearchTestCase {
         List<Sample> samples = Arrays.asList(new FloatSample(1500L, 15.5), new FloatSample(2500L, 25.5), new FloatSample(3500L, 35.5));
 
         // Act
-        List<List<Object>> result = TimeSeriesOutputMapper.transformSamplesToValues(samples);
+        List<List<Object>> result = TimeSeriesOutputMapper.transformSamplesToValues(SampleList.fromList(samples));
 
         // Assert
         assertThat(result, hasSize(3));
@@ -188,7 +189,7 @@ public class TimeSeriesOutputMapperTests extends OpenSearchTestCase {
 
     public void testTransformSamplesToValues_WithEmptySamples() {
         // Act
-        List<List<Object>> result = TimeSeriesOutputMapper.transformSamplesToValues(Collections.emptyList());
+        List<List<Object>> result = TimeSeriesOutputMapper.transformSamplesToValues(SampleList.fromList(Collections.emptyList()));
 
         // Assert
         assertThat(result, hasSize(0));


### PR DESCRIPTION
### Description

#### Motivation
We're currently using a `Sample` object to hold just two raw values, `value` and `timestamp`, the java object header is 8-12 bytes, so to hold two values of 16 bytes, we introduced at least 50% more memory overhead.  Please see details of benchmark here: https://github.com/opensearch-project/opensearch-tsdb-internal/pull/286 

#### Solution
One way to solve it is to use two parallel arrays, e.g. `double[] values` and `long[] timestamps`, and to reduce the usage of `Sample` object as much as possible, we should stop relying on `List<Sample>` as if we continue use that, we will unavoidably use `Sample`.

So this PR added a new interface `SampleList` to promote processing raw value/timestamp and also processing the samples as a whole instead of as a single object. And to make review/develop easier, currently under the hood it is still `List<Sample>` so in this PR we should expect minimum risk of functionality change.

In the next PR, I'll first make sure the `UnfoldAggregator` produces `SampleList` using the efficient representation (Like what was done in the above benchmark [demo PR](https://github.com/opensearch-project/opensearch-tsdb-internal/pull/286)), also rewrite such that we ensure no costly API is called in the production code.

Then we can start optimize the stages pieces by pieces to gradually minimize the usage of `Sample` interfaces.

#### Noticeable changes
There are still several places the behavior/how code is written is slightly changed in this PR, please pay more attention to those:
* AbstractBinaryProjectionStage — use iterator instead of indexes
* AbstractGroupingStage/AvgStage— slightly changes implementation of materialization
* PerSecondRateStage — remove null check and introduce NaN check instead, as we won’t insert null to current/future sample list

#### Why not use `SampleContainer`
We have previously defined [SampleContainer](https://github.com/opensearch-project/opensearch-tsdb-internal/blob/main/src/main/java/org/opensearch/tsdb/query/aggregator/SampleContainer.java) interface here, tho not used anywhere. I decided to not use/ modify it since that one seems more focused on how to efficiently represent timestamp and access/modify samples based on that, which is not what this PR currently focused on. If I choose to modify based on that one I probably will remove quite a few methods defined there and more or less the same as I creating a new interface. So I choose to leave it as is, and in the future if we decide to continue explore that work we can choose to add the methods in that interface to this one or vice-versa.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
