### PR TITLE
[CB] Remove unnecessary CircuitBreaker warn log

### DIFF
--- a/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
+++ b/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
@@ -512,28 +512,6 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
     );
 
     /**
-     * Setting for the circuit breaker warning threshold in aggregations.
-     * When an aggregation's circuit breaker allocation exceeds this threshold, a WARN log is emitted
-     * to help detect high cardinality queries or potential memory leaks early.
-     *
-     * <p>Default is 100 MB which is appropriate for most TSDB workloads:
-     * - Typical queries use &lt; 10 MB
-     * - High cardinality queries may use 10-50 MB
-     * - &gt; 100 MB indicates potential issues (excessive cardinality, memory leak, etc.)
-     *
-     * <p>This can be adjusted based on deployment size and use cases. For example:
-     * - Small deployments: 50 MB
-     * - Large deployments with high cardinality: 200 MB or higher
-     */
-    public static final Setting<Long> TSDB_ENGINE_AGGREGATION_CIRCUIT_BREAKER_WARN_THRESHOLD = Setting.longSetting(
-        "tsdb_engine.aggregation.circuit_breaker.warn_threshold",
-        100 * 1024 * 1024,  // default: 100 MB
-        1024 * 1024,        // minimum: 1 MB
-        Setting.Property.NodeScope,
-        Setting.Property.Dynamic
-    );
-
-    /**
      * Setting for the default step size (query resolution) for M3QL queries.
      * This defines the default time interval between data points in query results.
      * Can be overridden by the 'step' parameter in individual M3QL queries.
@@ -661,7 +639,6 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
             TSDB_ENGINE_WILDCARD_QUERY_CACHE_EXPIRE_AFTER,
             TSDB_ENGINE_FORCE_NO_PUSHDOWN,
             TSDB_ENGINE_ENABLE_INTERNAL_AGG_CHUNK_COMPRESSION,
-            TSDB_ENGINE_AGGREGATION_CIRCUIT_BREAKER_WARN_THRESHOLD,
             TSDB_ENGINE_DEFAULT_STEP,
             TSDB_ENGINE_REMOTE_INDEX_SETTINGS_CACHE_TTL,
             TSDB_ENGINE_REMOTE_INDEX_SETTINGS_CACHE_MAX_SIZE

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -144,13 +145,6 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
     private static final long ARRAYLIST_OVERHEAD = 24; // Estimated ArrayList object overhead
 
     /**
-     * Warning threshold for circuit breaker usage in bytes.
-     * When circuit breaker allocation exceeds this threshold, a WARN log is emitted.
-     * This value is read from the cluster setting tsdb_engine.aggregation.circuit_breaker.warn_threshold.
-     */
-    private final long circuitBreakerWarnThreshold;
-
-    /**
      * Set output series count for testing purposes.
      * Package-private for testing.
      */
@@ -189,16 +183,6 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
                     );
                 }
 
-                // Log at WARN level if total allocation exceeds threshold (potential memory issue)
-                if (circuitBreakerBytes > circuitBreakerWarnThreshold) {
-                    logger.warn(
-                        "High circuit breaker usage in aggregator '{}': {} bytes ({} MB). "
-                            + "This may indicate high cardinality data or memory leak.",
-                        name(),
-                        circuitBreakerBytes,
-                        circuitBreakerBytes / (1024 * 1024)
-                    );
-                }
             } catch (CircuitBreakingException e) {
                 // Try to get the original query source from SearchContext
                 String queryInfo = "unavailable";
@@ -217,29 +201,23 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
 
                 // Log detailed information about the query that was killed
                 logger.error(
-                    "Circuit breaker tripped - Query killed by circuit breaker. "
-                        + "Aggregation: [{}], "
-                        + "Query: {}, "
-                        + "Attempted allocation: {} bytes ({} MB), "
-                        + "Total allocated by this aggregation: {} bytes ({} MB), "
-                        + "Time range: [{} - {}], "
-                        + "Step: {}, "
-                        + "Pipeline stages: {}, "
-                        + "Circuit breaker limit: {} bytes ({} MB), "
-                        + "Reason: {}",
+                    "[request] Circuit breaker tripped: used [{}/{}mb] exceeds limit [{}/{}mb], "
+                        + "aggregation [{}]. "
+                        + "Attempted: {} bytes, Total by agg: {} bytes, "
+                        + "Time range: [{}-{}], Step: {}, Stages: {}. "
+                        + "Query: {}",
+                    e.getBytesWanted(),
+                    String.format(Locale.ROOT, "%.2f", e.getBytesWanted() / (1024.0 * 1024.0)),
+                    e.getByteLimit(),
+                    String.format(Locale.ROOT, "%.2f", e.getByteLimit() / (1024.0 * 1024.0)),
                     name(),
-                    queryInfo,
                     bytes,
-                    bytes / (1024.0 * 1024.0),
                     circuitBreakerBytes,
-                    circuitBreakerBytes / (1024.0 * 1024.0),
                     minTimestamp,
                     maxTimestamp,
                     step,
-                    stages != null ? stages.size() + " stages" : "no stages",
-                    e.getByteLimit(),
-                    e.getByteLimit() / (1024.0 * 1024.0),
-                    e.getMessage()
+                    stages != null ? stages.size() : 0,
+                    queryInfo
                 );
 
                 // Increment circuit breaker trips counter
@@ -264,7 +242,6 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
      * @param minTimestamp The minimum timestamp for filtering
      * @param maxTimestamp The maximum timestamp for filtering
      * @param step The step size for timestamp alignment
-     * @param circuitBreakerWarnThreshold The circuit breaker warning threshold in bytes
      * @param metadata The aggregation metadata
      * @throws IOException If an error occurs during initialization
      */
@@ -278,7 +255,6 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
         long minTimestamp,
         long maxTimestamp,
         long step,
-        long circuitBreakerWarnThreshold,
         Map<String, Object> metadata
     ) throws IOException {
         super(name, factories, context, parent, bucketCardinality, metadata);
@@ -287,21 +263,10 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
         this.minTimestamp = minTimestamp;
         this.maxTimestamp = maxTimestamp;
         this.step = step;
-        this.circuitBreakerWarnThreshold = circuitBreakerWarnThreshold;
 
         // Calculate theoretical maximum aligned timestamp
         // This is the largest timestamp aligned to (minTimestamp + N * step) that is < maxTimestamp
         this.theoreticalMaxTimestamp = TimeSeries.calculateAlignedMaxTimestamp(minTimestamp, maxTimestamp, step);
-    }
-
-    /**
-     * Get the circuit breaker warning threshold.
-     * Package-private for testing.
-     *
-     * @return the circuit breaker warning threshold in bytes
-     */
-    long getCircuitBreakerWarnThreshold() {
-        return circuitBreakerWarnThreshold;
     }
 
     @Override
@@ -645,7 +610,6 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
             }
             return results;
         } finally {
-            // Emit all metrics in one batch - minimal overhead
             recordMetrics();
         }
     }

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregatorFactory.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregatorFactory.java
@@ -7,7 +7,6 @@
  */
 package org.opensearch.tsdb.query.aggregator;
 
-import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.search.aggregations.Aggregator;
 import org.opensearch.search.aggregations.AggregatorFactories;
@@ -15,8 +14,6 @@ import org.opensearch.search.aggregations.AggregatorFactory;
 import org.opensearch.search.aggregations.CardinalityUpperBound;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
-
-import static org.opensearch.tsdb.TSDBPlugin.TSDB_ENGINE_AGGREGATION_CIRCUIT_BREAKER_WARN_THRESHOLD;
 
 import java.io.IOException;
 import java.util.List;
@@ -48,7 +45,6 @@ public class TimeSeriesUnfoldAggregatorFactory extends AggregatorFactory {
     private final long minTimestamp;
     private final long maxTimestamp;
     private final long step;
-    private final long circuitBreakerWarnThreshold;
 
     /**
      * Create a time series unfold aggregator factory.
@@ -80,11 +76,6 @@ public class TimeSeriesUnfoldAggregatorFactory extends AggregatorFactory {
         this.minTimestamp = minTimestamp;
         this.maxTimestamp = maxTimestamp;
         this.step = step;
-        // Read circuit breaker warning threshold from cluster settings
-        // Use default value if queryShardContext is null (e.g., in tests)
-        this.circuitBreakerWarnThreshold = (queryShardContext != null && queryShardContext.getIndexSettings() != null)
-            ? TSDB_ENGINE_AGGREGATION_CIRCUIT_BREAKER_WARN_THRESHOLD.get(queryShardContext.getIndexSettings().getNodeSettings())
-            : TSDB_ENGINE_AGGREGATION_CIRCUIT_BREAKER_WARN_THRESHOLD.getDefault(Settings.EMPTY);
     }
 
     @Override
@@ -104,7 +95,6 @@ public class TimeSeriesUnfoldAggregatorFactory extends AggregatorFactory {
             minTimestamp,
             maxTimestamp,
             step,
-            circuitBreakerWarnThreshold,
             metadata
         );
     }

--- a/src/test/java/org/opensearch/tsdb/TSDBPluginTests.java
+++ b/src/test/java/org/opensearch/tsdb/TSDBPluginTests.java
@@ -77,7 +77,7 @@ public class TSDBPluginTests extends OpenSearchTestCase {
         List<Setting<?>> settings = plugin.getSettings();
 
         assertNotNull("Settings list should not be null", settings);
-        assertThat("Should have 24 settings", settings, hasSize(24));
+        assertThat("Should have 23 settings", settings, hasSize(23));
 
         // Verify TSDB_ENGINE_ENABLED is present
         assertTrue("Should contain TSDB_ENGINE_ENABLED setting", settings.contains(TSDBPlugin.TSDB_ENGINE_ENABLED));

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregatorTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregatorTests.java
@@ -233,14 +233,6 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
      * Creates a TimeSeriesUnfoldAggregator for testing.
      */
     private TimeSeriesUnfoldAggregator createAggregator(long minTimestamp, long maxTimestamp, long step) throws IOException {
-        return createAggregator(minTimestamp, maxTimestamp, step, 100 * 1024 * 1024); // Default 100 MB
-    }
-
-    /**
-     * Creates a TimeSeriesUnfoldAggregator for testing with custom circuit breaker threshold.
-     */
-    private TimeSeriesUnfoldAggregator createAggregator(long minTimestamp, long maxTimestamp, long step, long circuitBreakerWarnThreshold)
-        throws IOException {
         SearchContext mockSearchContext = mock(SearchContext.class);
         QueryShardContext mockQueryShardContext = mock(QueryShardContext.class);
 
@@ -260,7 +252,6 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
             minTimestamp,
             maxTimestamp,
             step,
-            circuitBreakerWarnThreshold,
             Map.of()
         );
     }
@@ -572,24 +563,6 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that the circuit breaker warning threshold is correctly applied.
-     * When allocation exceeds the threshold, a warning should be logged.
-     */
-    public void testCircuitBreakerWarnThreshold() throws IOException {
-        long minTimestamp = 1000L;
-        long maxTimestamp = 5000L;
-        long step = 100L;
-        long warnThreshold = 50 * 1024; // 50 KB
-
-        TimeSeriesUnfoldAggregator aggregator = createAggregator(minTimestamp, maxTimestamp, step, warnThreshold);
-
-        // Verify threshold is set correctly
-        assertEquals("Warning threshold should match constructor parameter", warnThreshold, aggregator.getCircuitBreakerWarnThreshold());
-
-        aggregator.close();
-    }
-
-    /**
      * Tests that buildAggregation returns profile debug info when profile is enabled.
      */
     public void testBuildAggregationDebugInfo() throws IOException {
@@ -617,7 +590,6 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
             minTimestamp,
             maxTimestamp,
             step,
-            100 * 1024 * 1024,
             Map.of()
         );
 
@@ -695,24 +667,23 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests the warning threshold logging path.
+     * Tests that circuit breaker bytes accumulate correctly.
+     * Note: Warning threshold is now dynamic and read from cluster settings.
      */
-    public void testAddCircuitBreakerBytesWarnThresholdExceeded() throws IOException {
+    public void testAddCircuitBreakerBytesAccumulation() throws IOException {
         long minTimestamp = 1000L;
         long maxTimestamp = 5000L;
         long step = 100L;
-        long warnThreshold = 1000; // Set a low threshold for testing
 
-        TimeSeriesUnfoldAggregator aggregator = createAggregator(minTimestamp, maxTimestamp, step, warnThreshold);
+        TimeSeriesUnfoldAggregator aggregator = createAggregator(minTimestamp, maxTimestamp, step);
 
-        // Add bytes below threshold - no warning
+        // Add bytes
         aggregator.addCircuitBreakerBytesForTesting(500);
         assertEquals("Circuit breaker bytes should be 500", 500L, aggregator.circuitBreakerBytes);
 
-        // Add more bytes to exceed threshold - should trigger warning log
+        // Add more bytes - should accumulate
         aggregator.addCircuitBreakerBytesForTesting(600);
         assertEquals("Circuit breaker bytes should be 1100", 1100L, aggregator.circuitBreakerBytes);
-        assertTrue("Total should exceed threshold", aggregator.circuitBreakerBytes > warnThreshold);
 
         aggregator.close();
     }
@@ -768,7 +739,6 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
             1000L,
             5000L,
             100L,
-            100 * 1024 * 1024,
             Map.of()
         );
     }
@@ -939,7 +909,7 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
             when(mockSearchContext.request()).thenReturn(null);
             when(mockSearchContext.query()).thenReturn(null);
 
-            TimeSeriesUnfoldAggregator aggregator = createAggregatorWithDelayedTripBreaker(mockSearchContext, 1, List.of());
+            TimeSeriesUnfoldAggregator aggregator = createAggregatorWithDelayedTripBreaker(mockSearchContext, 1, null);
 
             CircuitBreakingException exception = expectThrows(
                 CircuitBreakingException.class,


### PR DESCRIPTION
### Description
Remove the unecessary WARN log on high memory usage, since if the breaker actually trips, there is an ERROR log with full query info 

<img width="1837" height="175" alt="Screenshot 2026-02-02 at 6 00 36 PM" src="https://github.com/user-attachments/assets/dca81ff0-02e6-41bb-8a82-54aad9908b5a" />

Also remove the setting associated with it

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
