### PR TITLE
Use mb instead of bytes for CB histogram metrics

### DIFF
--- a/src/main/java/org/opensearch/tsdb/metrics/TSDBAggregationMetrics.java
+++ b/src/main/java/org/opensearch/tsdb/metrics/TSDBAggregationMetrics.java
@@ -57,8 +57,8 @@ public class TSDBAggregationMetrics {
     /** Histogram for number of series returned per query */
     public Histogram seriesTotal;
 
-    /** Histogram for circuit breaker MB tracked per aggregation request */
-    public Histogram circuitBreakerMB;
+    /** Histogram for circuit breaker MiB tracked per aggregation request */
+    public Histogram circuitBreakerMiB;
 
     /** Counter for circuit breaker trips (when memory limit exceeded) */
     public Counter circuitBreakerTrips;
@@ -140,10 +140,10 @@ public class TSDBAggregationMetrics {
             TSDBMetricsConstants.AGGREGATION_SERIES_TOTAL_DESC,
             TSDBMetricsConstants.UNIT_COUNT
         );
-        circuitBreakerMB = registry.createHistogram(
-            TSDBMetricsConstants.AGGREGATION_CIRCUIT_BREAKER_MB,
-            TSDBMetricsConstants.AGGREGATION_CIRCUIT_BREAKER_MB_DESC,
-            TSDBMetricsConstants.UNIT_MEGABYTES
+        circuitBreakerMiB = registry.createHistogram(
+            TSDBMetricsConstants.AGGREGATION_CIRCUIT_BREAKER_MIB,
+            TSDBMetricsConstants.AGGREGATION_CIRCUIT_BREAKER_MIB_DESC,
+            TSDBMetricsConstants.UNIT_MEBIBYTES
         );
         circuitBreakerTrips = registry.createCounter(
             TSDBMetricsConstants.AGGREGATION_CIRCUIT_BREAKER_TRIPS_TOTAL,
@@ -175,7 +175,7 @@ public class TSDBAggregationMetrics {
         chunksForDocErrors = null;
         resultsTotal = null;
         seriesTotal = null;
-        circuitBreakerMB = null;
+        circuitBreakerMiB = null;
         circuitBreakerTrips = null;
         pipelineStageLatency = null;
     }

--- a/src/main/java/org/opensearch/tsdb/metrics/TSDBMetricsConstants.java
+++ b/src/main/java/org/opensearch/tsdb/metrics/TSDBMetricsConstants.java
@@ -124,8 +124,8 @@ public final class TSDBMetricsConstants {
     /** Histogram: Number of time series returned per query */
     public static final String AGGREGATION_SERIES_TOTAL = "tsdb.aggregation.series.total";
 
-    /** Histogram: Circuit breaker MB tracked per aggregation request */
-    public static final String AGGREGATION_CIRCUIT_BREAKER_MB = "tsdb.aggregation.circuit_breaker.mb";
+    /** Histogram: Circuit breaker MiB tracked per aggregation request */
+    public static final String AGGREGATION_CIRCUIT_BREAKER_MIB = "tsdb.aggregation.circuit_breaker.mib";
 
     /** Counter: Circuit breaker trips (when memory limit exceeded) */
     public static final String AGGREGATION_CIRCUIT_BREAKER_TRIPS_TOTAL = "tsdb.aggregation.circuit_breaker.trips.total";
@@ -282,8 +282,8 @@ public final class TSDBMetricsConstants {
     public static final String AGGREGATION_CHUNKS_FOR_DOC_ERRORS_TOTAL_DESC = "Total errors in chunksForDoc() operations";
     public static final String AGGREGATION_RESULTS_TOTAL_DESC = "Total queries tagged by result status (empty or hits)";
     public static final String AGGREGATION_SERIES_TOTAL_DESC = "Number of time series returned per query";
-    public static final String AGGREGATION_CIRCUIT_BREAKER_MB_DESC =
-        "Circuit breaker MB tracked per aggregation request (measures memory usage)";
+    public static final String AGGREGATION_CIRCUIT_BREAKER_MIB_DESC =
+        "Circuit breaker MiB tracked per aggregation request (measures memory usage)";
     public static final String AGGREGATION_CIRCUIT_BREAKER_TRIPS_TOTAL_DESC = "Total circuit breaker trips when memory limit exceeded";
     public static final String AGGREGATION_PIPELINE_STAGE_LATENCY_DESC = "Latency per pipeline stage execution";
 
@@ -383,6 +383,6 @@ public final class TSDBMetricsConstants {
     /** Unit for bytes */
     public static final String UNIT_BYTES = "bytes";
 
-    /** Unit for megabytes */
-    public static final String UNIT_MEGABYTES = "MB";
+    /** Unit for mebibytes (UCUM: MiBy) */
+    public static final String UNIT_MEBIBYTES = "MiBy";
 }

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
@@ -707,9 +707,9 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
                 TSDBMetrics.incrementCounter(TSDBMetrics.AGGREGATION.resultsTotal, 1, TAGS_STATUS_EMPTY);
             }
 
-            // Record circuit breaker MB (histogram for distribution tracking)
+            // Record circuit breaker MiB (histogram for distribution tracking)
             if (circuitBreakerBytes > 0) {
-                TSDBMetrics.recordHistogram(TSDBMetrics.AGGREGATION.circuitBreakerMB, circuitBreakerBytes / (1024.0 * 1024.0));
+                TSDBMetrics.recordHistogram(TSDBMetrics.AGGREGATION.circuitBreakerMiB, circuitBreakerBytes / (1024.0 * 1024.0));
             }
         } catch (Exception e) {
             // Swallow exceptions in metrics recording to avoid impacting actual operation

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregatorTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregatorTests.java
@@ -339,7 +339,7 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
     }
 
     /**
-     * Tests that recordMetrics correctly records circuit breaker MB histogram when circuitBreakerBytes > 0.
+     * Tests that recordMetrics correctly records circuit breaker MiB histogram when circuitBreakerBytes > 0.
      */
     public void testRecordMetricsWithCircuitBreakerBytes() throws IOException {
         // Initialize TSDBMetrics with mock registry
@@ -348,9 +348,9 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
 
         // Default histogram for other metrics (must be defined first)
         when(mockRegistry.createHistogram(anyString(), anyString(), anyString())).thenReturn(mock(Histogram.class));
-        // Create a specific mock for the circuit breaker MB histogram (defined last to take precedence)
-        Histogram circuitBreakerMBHistogram = mock(Histogram.class);
-        when(mockRegistry.createHistogram(contains("circuit_breaker.mb"), anyString(), anyString())).thenReturn(circuitBreakerMBHistogram);
+        // Create a specific mock for the circuit breaker MiB histogram (defined last to take precedence)
+        Histogram circuitBreakerMiBHistogram = mock(Histogram.class);
+        when(mockRegistry.createHistogram(contains("circuit_breaker.mib"), anyString(), anyString())).thenReturn(circuitBreakerMiBHistogram);
 
         TSDBMetrics.initialize(mockRegistry);
 
@@ -362,11 +362,11 @@ public class TimeSeriesUnfoldAggregatorTests extends OpenSearchTestCase {
             TimeSeriesUnfoldAggregator aggregator = createAggregator(minTimestamp, maxTimestamp, step);
 
             // Set circuit breaker bytes > 0 to trigger the histogram recording path
-            aggregator.circuitBreakerBytes = 10 * 1024 * 1024; // 10 MB
+            aggregator.circuitBreakerBytes = 10 * 1024 * 1024; // 10 MiB
             aggregator.recordMetrics();
 
-            // Verify the histogram was called with the correct value (10 MB)
-            verify(circuitBreakerMBHistogram).record(eq(10.0), eq(Tags.EMPTY));
+            // Verify the histogram was called with the correct value (10 MiB)
+            verify(circuitBreakerMiBHistogram).record(eq(10.0), eq(Tags.EMPTY));
 
             aggregator.close();
 


### PR DESCRIPTION
### Description
Our histograms buckets only range from 1 - 2M. 
 
- 2M bytes is only 2MB, which is too small for circuit breaker measurement. 
- 2M kilobytes is only 2GB, which could potentially be exceeded as well, as nodes are 128GB.

Thus we use MB instead as the unit, so this metric will support values ranging from 1MB to 2TB.

Note that other metrics using bytes as units will also have to be audited/fixed, in separate PRs. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
