### PR TITLE
Adding parallel processing to AbstractGroupingSampleStage

### DIFF
--- a/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
+++ b/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
@@ -599,6 +599,12 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
     );
 
     // ========== Grouping Stage Parallel Processing Settings ==========
+    // These settings are cluster-level (NodeScope) rather than index-level because grouping stage
+    // parallel processing runs at the coordinator node during query execution (especially in
+    // cross-cluster search scenarios). The coordinator aggregates results from all shards/clusters,
+    // and the parallelism decision depends on the total data volume arriving at the coordinator,
+    // not on individual index properties. Index-level settings would not be meaningful here since
+    // the coordinator processes data from potentially many indexes and clusters simultaneously.
 
     /**
      * Enable or disable parallel processing for grouping stages (sum, avg, min, max, count, etc.).
@@ -617,14 +623,16 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
     /**
      * Minimum number of time series to trigger parallel processing within a grouping stage.
      * Below this threshold, sequential processing is used to avoid thread overhead.
+     * Both this and {@link #GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD} must be met for parallel
+     * processing to activate, ensuring sufficient total work (series x samples) to justify
+     * the thread coordination overhead.
      *
      * <p>Default: 1000 series</p>
      */
     public static final Setting<Integer> GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD = Setting.intSetting(
         "tsdb_engine.query.grouping_stage.parallel_processing.series_threshold",
         1000, // default
-        0, // min (0 = always parallel)
-        100000, // max
+        0, // min (0 = always parallel when enabled)
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -632,6 +640,9 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
     /**
      * Minimum average number of samples per series to trigger parallel processing in grouping stages.
      * This prevents parallelizing sparse time series where overhead may dominate.
+     * Both this and {@link #GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD} must be met for parallel
+     * processing to activate, ensuring sufficient total work (series x samples) to justify
+     * the thread coordination overhead.
      *
      * <p>Default: 100 samples</p>
      */
@@ -639,7 +650,6 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
         "tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold",
         100, // default
         0, // min
-        10000, // max
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
+++ b/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
@@ -602,14 +602,14 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
 
     /**
      * Enable or disable parallel processing for grouping stages (sum, avg, min, max, count, etc.).
-     * When disabled, grouping stages always use sequential processing.
+     * When enabled, grouping stages use parallel processing.
      * Useful for debugging or when predictable single-threaded behavior is desired.
      *
-     * <p>Default: true (enabled)</p>
+     * <p>Default: false (disabled)</p>
      */
     public static final Setting<Boolean> GROUPING_STAGE_PARALLEL_ENABLED = Setting.boolSetting(
         "tsdb_engine.query.grouping_stage.parallel_processing.enabled",
-        true, // default
+        false, // default
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
+++ b/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
@@ -73,6 +73,7 @@ import org.opensearch.tsdb.query.rest.RemoteIndexSettingsCache;
 import org.opensearch.tsdb.query.rest.RestM3QLAction;
 import org.opensearch.tsdb.query.rest.RestPromQLAction;
 import org.opensearch.tsdb.query.rest.RestTSDBStatsAction;
+import org.opensearch.tsdb.query.stage.ParallelProcessingConfig;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.io.IOException;
@@ -597,6 +598,52 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
         Setting.Property.Dynamic
     );
 
+    // ========== Grouping Stage Parallel Processing Settings ==========
+
+    /**
+     * Enable or disable parallel processing for grouping stages (sum, avg, min, max, count, etc.).
+     * When disabled, grouping stages always use sequential processing.
+     * Useful for debugging or when predictable single-threaded behavior is desired.
+     *
+     * <p>Default: true (enabled)</p>
+     */
+    public static final Setting<Boolean> GROUPING_STAGE_PARALLEL_ENABLED = Setting.boolSetting(
+        "tsdb_engine.query.grouping_stage.parallel_processing.enabled",
+        true, // default
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Minimum number of time series to trigger parallel processing within a grouping stage.
+     * Below this threshold, sequential processing is used to avoid thread overhead.
+     *
+     * <p>Default: 1000 series</p>
+     */
+    public static final Setting<Integer> GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD = Setting.intSetting(
+        "tsdb_engine.query.grouping_stage.parallel_processing.series_threshold",
+        1000, // default
+        0, // min (0 = always parallel)
+        100000, // max
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Minimum average number of samples per series to trigger parallel processing in grouping stages.
+     * This prevents parallelizing sparse time series where overhead may dominate.
+     *
+     * <p>Default: 100 samples</p>
+     */
+    public static final Setting<Integer> GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD = Setting.intSetting(
+        "tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold",
+        100, // default
+        0, // min
+        10000, // max
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     /**
      * Setting to enable/disable coordinator ingestion lag metric (Metric 1).
      * When disabled, TSDBIngestionLagActionFilter will skip metric collection.
@@ -626,7 +673,7 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
 
     /**
      * Initialize metrics if telemetry is available.
-     * Also initializes the wildcard query cache with cluster settings.
+     * Also initializes the wildcard query cache and parallel processing config with cluster settings.
      */
     @Override
     public java.util.Collection<Object> createComponents(
@@ -723,6 +770,9 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
         // Initialize wildcard query cache with cluster-level settings
         CachedWildcardQueryBuilder.initializeCache(clusterService.getClusterSettings(), clusterService.getSettings());
 
+        // Initialize parallel processing config for grouping stages with cluster-level settings
+        ParallelProcessingConfig.initialize(clusterService.getClusterSettings(), clusterService.getSettings());
+
         return Collections.emptyList();
     }
 
@@ -755,7 +805,10 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
             TSDB_ENGINE_REMOTE_INDEX_SETTINGS_CACHE_MAX_SIZE,
             TSDB_INGESTION_LAG_COORDINATOR_METRICS_ENABLED,
             TSDB_INGESTION_LAG_SEARCHABLE_METRICS_ENABLED,
-            TSDB_ENGINE_INTERNAL_TIME_SERIES_FORMAT
+            TSDB_ENGINE_INTERNAL_TIME_SERIES_FORMAT,
+            GROUPING_STAGE_PARALLEL_ENABLED,
+            GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD,
+            GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD
         );
     }
 

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
@@ -46,7 +46,7 @@ import org.opensearch.tsdb.query.utils.RamUsageConstants;
  *   <li><strong>Parallel:</strong> Used for large datasets to leverage multi-core CPUs at coordinator level</li>
  * </ul>
  *
- * <p>Parallel processing uses thread-local aggregation (no shared map contention) then merges
+ * <p>Parallel processing uses thread-local aggregation then merges
  * results, with work executed via {@link java.util.concurrent.ForkJoinPool} common pool.</p>
  */
 public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingStage {

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map.Entry;
 import java.util.function.LongConsumer;
 
 import org.apache.lucene.util.RamUsageEstimator;
@@ -46,8 +46,8 @@ import org.opensearch.tsdb.query.utils.RamUsageConstants;
  *   <li><strong>Parallel:</strong> Used for large datasets to leverage multi-core CPUs at coordinator level</li>
  * </ul>
  *
- * <p>Parallel processing uses {@link ConcurrentHashMap} for thread-safe aggregation and
- * {@link java.util.concurrent.ForkJoinPool} common pool for work-stealing execution.</p>
+ * <p>Parallel processing uses thread-local aggregation (no shared map contention) then merges
+ * results, with work executed via {@link java.util.concurrent.ForkJoinPool} common pool.</p>
  */
 public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingStage {
 
@@ -229,10 +229,9 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
      *
      * <p>Implementation notes:</p>
      * <ul>
-     *   <li>Uses {@link ConcurrentHashMap} for thread-safe aggregation</li>
+     *   <li>Each thread aggregates a subset of series into a local map (no lock contention)</li>
+     *   <li>Local maps are then reduced by merging buckets per timestamp via {@link #mergeBuckets}</li>
      *   <li>Uses parallel streams backed by {@link java.util.concurrent.ForkJoinPool#commonPool()}</li>
-     *   <li>Each time series is processed independently</li>
-     *   <li>ConcurrentHashMap.compute provides atomic, thread-safe aggregation per timestamp</li>
      * </ul>
      *
      * @param groupSeries List of time series in the same group
@@ -244,12 +243,12 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         long timeRange = firstSeries.getMaxTimestamp() - firstSeries.getMinTimestamp();
         int expectedTimestamps = (int) (timeRange / firstSeries.getStep()) + 1;
 
-        // Use ConcurrentHashMap for thread-safe aggregation
-        // Initial capacity based on expected timestamps, with high load factor to minimize resizing
-        ConcurrentHashMap<Long, A> timestampToAggregated = new ConcurrentHashMap<>(expectedTimestamps, 0.9f);
-
-        // Process all time series in parallel
-        groupSeries.parallelStream().forEach(series -> aggregateSamplesIntoMap(series.getSamples(), timestampToAggregated));
+        // Each thread aggregates into a local map, then we merge (avoids per-key contention)
+        Map<Long, A> timestampToAggregated = groupSeries.parallelStream().map(series -> {
+            Map<Long, A> local = HashMap.newHashMap(expectedTimestamps);
+            aggregateSamplesIntoMap(series.getSamples(), local);
+            return local;
+        }).reduce(new HashMap<>(), this::mergeLocalMaps);
 
         // Create sorted samples - pre-allocate since we know the exact size
         List<Sample> aggregatedSamples = new ArrayList<>(timestampToAggregated.size());
@@ -350,12 +349,10 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
     }
 
     /**
-     * Parallel reduce implementation using ConcurrentHashMap for thread-safe aggregation.
-     * Uses the same {@link #aggregateSamplesIntoMap} logic as the sequential path so results
-     * are identical to main's reduceGrouped.
-     *
-     * <p>This method processes time series from multiple shards in parallel, significantly
-     * improving performance for large datasets at coordinator level when pushdown is disabled.</p>
+     * Parallel reduce implementation using thread-local aggregation then merge (same pattern as
+     * {@link #processGroupParallel}). Each thread aggregates one or more aggregations into a local
+     * {@code Map<ByteLabels, Map<Long, A>>}, then partial results are combined via {@link #mergeGroupMaps}.
+     * Avoids per-key contention by not sharing maps across threads.
      */
     private InternalAggregation reduceGroupedParallel(
         List<TimeSeriesProvider> aggregations,
@@ -364,32 +361,44 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         boolean isFinalReduce,
         LongConsumer circuitBreakerConsumer
     ) {
-        // Use ConcurrentHashMap for thread-safe group aggregation
-        // Outer map: group labels -> timestamp map. Use compute() (not computeIfAbsent) so
-        // only one inner map is created per group when multiple threads hit the same key.
-        ConcurrentHashMap<ByteLabels, ConcurrentHashMap<Long, A>> groupToTimestampBucket = new ConcurrentHashMap<>();
-
-        // Process all aggregations in parallel
-        aggregations.parallelStream().forEach(aggregation -> {
+        Map<ByteLabels, Map<Long, A>> groupToTimestampBucket = aggregations.parallelStream().map(aggregation -> {
+            Map<ByteLabels, Map<Long, A>> local = new HashMap<>();
             for (TimeSeries series : aggregation.getTimeSeries()) {
                 ByteLabels groupLabels = extractGroupLabelsDirect(series);
-
-                // Get or create timestamp map for this group atomically (compute guarantees single map per group)
-                ConcurrentHashMap<Long, A> timestampToBucket = groupToTimestampBucket.compute(
-                    groupLabels,
-                    (k, existing) -> existing != null ? existing : new ConcurrentHashMap<>()
-                );
-
-                // Same aggregation logic as sequential path and main's reduceGrouped
+                Map<Long, A> timestampToBucket = local.computeIfAbsent(groupLabels, k -> new HashMap<>());
                 aggregateSamplesIntoMap(series.getSamples(), timestampToBucket);
             }
-        });
+            return local;
+        }).reduce(new HashMap<>(), this::mergeGroupMaps);
 
-        // Convert ConcurrentHashMap to regular HashMap for finalization
-        Map<ByteLabels, Map<Long, A>> regularMap = new HashMap<>(groupToTimestampBucket.size());
-        groupToTimestampBucket.forEach((groupLabels, timestampToBucket) -> regularMap.put(groupLabels, new HashMap<>(timestampToBucket)));
+        return finalizeReduction(groupToTimestampBucket, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
+    }
 
-        return finalizeReduction(regularMap, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
+    /**
+     * Merge two group→timestamp maps (used when reducing parallel reduce partials).
+     * Must not mutate either argument so the combiner is safe when the same identity is
+     * reused in parallel (stream reduce can call combine(identity, p1) and combine(identity, p2)
+     * in different threads, then combine those results).
+     */
+    private Map<ByteLabels, Map<Long, A>> mergeGroupMaps(Map<ByteLabels, Map<Long, A>> a, Map<ByteLabels, Map<Long, A>> b) {
+        if (a.isEmpty()) {
+            return b;
+        }
+        if (b.isEmpty()) {
+            return a;
+        }
+        // Copy a so we never mutate the shared identity; then merge b into the copy
+        Map<ByteLabels, Map<Long, A>> result = new HashMap<>();
+        for (Entry<ByteLabels, Map<Long, A>> e : a.entrySet()) {
+            result.put(e.getKey(), new HashMap<>(e.getValue()));
+        }
+        for (Entry<ByteLabels, Map<Long, A>> e : b.entrySet()) {
+            Map<Long, A> resultTs = result.computeIfAbsent(e.getKey(), k -> new HashMap<>());
+            for (Entry<Long, A> be : e.getValue().entrySet()) {
+                resultTs.compute(be.getKey(), (ts, x) -> mergeBuckets(x, be.getValue(), ts));
+            }
+        }
+        return result;
     }
 
     /**
@@ -474,6 +483,38 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
             builder.add(sampleEntry.getKey(), sampleEntry.getValue());
         });
         return builder.build();
+    }
+
+    /**
+     * Merge two aggregation buckets for the same timestamp (used when reducing thread-local maps).
+     * Default: treat the second bucket as a single sample and aggregate into the first.
+     * Override in stages where buckets must be combined differently (e.g. percentile sorted lists).
+     *
+     * @param existing current bucket for the timestamp (null if none yet)
+     * @param toMerge bucket from another thread to merge in
+     * @param timestamp the timestamp (for sample conversion when needed)
+     * @return merged bucket
+     */
+    protected A mergeBuckets(@Nullable A existing, A toMerge, long timestamp) {
+        return aggregateSingleSample(existing, bucketToSample(timestamp, toMerge));
+    }
+
+    /**
+     * Merge two thread-local timestamp→bucket maps into one. Does not mutate either argument
+     * so the combiner is safe when used with parallel stream reduce (identity may be reused).
+     */
+    private Map<Long, A> mergeLocalMaps(Map<Long, A> a, Map<Long, A> b) {
+        if (a.isEmpty()) {
+            return b;
+        }
+        if (b.isEmpty()) {
+            return a;
+        }
+        Map<Long, A> result = new HashMap<>(a);
+        for (Entry<Long, A> e : b.entrySet()) {
+            result.compute(e.getKey(), (ts, x) -> mergeBuckets(x, e.getValue(), ts));
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.tsdb.lang.m3.stage;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.Nullable;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.search.aggregations.InternalAggregation;
@@ -18,12 +20,14 @@ import org.opensearch.tsdb.core.model.Sample;
 import org.opensearch.tsdb.core.model.SampleList;
 import org.opensearch.tsdb.query.aggregator.TimeSeries;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesProvider;
+import org.opensearch.tsdb.query.stage.ParallelProcessingConfig;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongConsumer;
 
 import org.apache.lucene.util.RamUsageEstimator;
@@ -35,8 +39,26 @@ import org.opensearch.tsdb.query.utils.RamUsageConstants;
  * aggregation functions within each group for each sample.
  *
  * @param <A> The type of class used as aggregation bucket, concrete class typically should specify this type
+ *
+ * <p>This implementation supports both sequential and parallel processing modes:</p>
+ * <ul>
+ *   <li><strong>Sequential:</strong> Used for small datasets (&lt; 1000 series) to avoid thread overhead</li>
+ *   <li><strong>Parallel:</strong> Used for large datasets to leverage multi-core CPUs at coordinator level</li>
+ * </ul>
+ *
+ * <p>Parallel processing uses {@link ConcurrentHashMap} for thread-safe aggregation and
+ * {@link java.util.concurrent.ForkJoinPool} common pool for work-stealing execution.</p>
  */
 public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingStage {
+
+    private static final Logger logger = LogManager.getLogger(AbstractGroupingSampleStage.class);
+
+    /**
+     * Configuration for parallel processing thresholds in grouping stages.
+     * Uses default config since stages don't have access to cluster settings.
+     * Can be overridden via setParallelConfig for testing.
+     */
+    private static volatile ParallelProcessingConfig parallelConfig = ParallelProcessingConfig.defaultConfig();
 
     /**
      * Constructor for aggregation without label grouping.
@@ -59,6 +81,25 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
      */
     protected AbstractGroupingSampleStage(String groupByLabel) {
         super(groupByLabel);
+    }
+
+    /**
+     * Set the parallel processing configuration for grouping stages.
+     * Primarily intended for testing to control parallel vs sequential execution.
+     *
+     * @param config the parallel processing configuration to use
+     */
+    public static void setParallelConfig(ParallelProcessingConfig config) {
+        parallelConfig = config;
+    }
+
+    /**
+     * Get the current parallel processing configuration for grouping stages.
+     *
+     * @return the current configuration
+     */
+    public static ParallelProcessingConfig getParallelConfig() {
+        return parallelConfig;
     }
 
     @Override
@@ -96,14 +137,59 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
      * This method handles the common aggregation logic while delegating
      * operation-specific behavior to abstract methods.
      *
+     * <p>Automatically selects sequential or parallel processing based on dataset size.</p>
+     *
      * @param groupSeries List of time series in the same group
      * @param groupLabels The labels for this group (null if no grouping)
      * @return Single processed time series for this group
      */
     @Override
     protected final TimeSeries processGroup(List<TimeSeries> groupSeries, Labels groupLabels) {
-        // Calculate expected number of unique timestamps based on time range and step
+        if (groupSeries.isEmpty()) {
+            throw new IllegalArgumentException("groupSeries must not be empty");
+        }
         TimeSeries firstSeries = groupSeries.get(0);
+        int seriesCount = groupSeries.size();
+
+        int totalSamples = 0;
+        for (TimeSeries series : groupSeries) {
+            totalSamples += series.getSamples().size();
+        }
+        int avgSamplesPerSeries = totalSamples / seriesCount;
+
+        // Determine if parallel processing should be used
+        boolean useParallel = parallelConfig.shouldUseParallelProcessing(seriesCount, avgSamplesPerSeries);
+
+        if (useParallel) {
+            logger.debug(
+                "Using parallel processing for stage={}, seriesCount={}, avgSamplesPerSeries={}",
+                getName(),
+                seriesCount,
+                avgSamplesPerSeries
+            );
+            return processGroupParallel(groupSeries, groupLabels, firstSeries);
+        } else {
+            logger.debug(
+                "Using sequential processing for stage={}, seriesCount={}, avgSamplesPerSeries={}",
+                getName(),
+                seriesCount,
+                avgSamplesPerSeries
+            );
+            return processGroupSequential(groupSeries, groupLabels, firstSeries);
+        }
+    }
+
+    /**
+     * Process a group of time series sequentially (original implementation).
+     * Used for small datasets where thread overhead is not justified.
+     *
+     * @param groupSeries List of time series in the same group
+     * @param groupLabels The labels for this group (null if no grouping)
+     * @param firstSeries The first time series (for metadata extraction)
+     * @return Single processed time series for this group
+     */
+    private TimeSeries processGroupSequential(List<TimeSeries> groupSeries, Labels groupLabels, TimeSeries firstSeries) {
+        // Calculate expected number of unique timestamps based on time range and step
         long timeRange = firstSeries.getMaxTimestamp() - firstSeries.getMinTimestamp();
         int expectedTimestamps = (int) (timeRange / firstSeries.getStep()) + 1;
 
@@ -144,6 +230,63 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         );
     }
 
+    /**
+     * Process a group of time series in parallel using ForkJoinPool.
+     * Used for large datasets to leverage multi-core CPUs.
+     *
+     * <p>Implementation notes:</p>
+     * <ul>
+     *   <li>Uses {@link ConcurrentHashMap} for thread-safe aggregation</li>
+     *   <li>Uses parallel streams backed by {@link java.util.concurrent.ForkJoinPool#commonPool()}</li>
+     *   <li>Each time series is processed independently</li>
+     *   <li>ConcurrentHashMap.compute provides atomic, thread-safe aggregation per timestamp</li>
+     * </ul>
+     *
+     * @param groupSeries List of time series in the same group
+     * @param groupLabels The labels for this group (null if no grouping)
+     * @param firstSeries The first time series (for metadata extraction)
+     * @return Single processed time series for this group
+     */
+    private TimeSeries processGroupParallel(List<TimeSeries> groupSeries, Labels groupLabels, TimeSeries firstSeries) {
+        long timeRange = firstSeries.getMaxTimestamp() - firstSeries.getMinTimestamp();
+        int expectedTimestamps = (int) (timeRange / firstSeries.getStep()) + 1;
+
+        // Use ConcurrentHashMap for thread-safe aggregation
+        // Initial capacity based on expected timestamps, with high load factor to minimize resizing
+        ConcurrentHashMap<Long, A> timestampToAggregated = new ConcurrentHashMap<>(expectedTimestamps, 0.9f);
+
+        // Process all time series in parallel
+        groupSeries.parallelStream().forEach(series -> {
+            for (Sample sample : series.getSamples()) {
+                // Skip NaN values - treat them as null/missing
+                if (Double.isNaN(sample.getValue())) {
+                    continue;
+                }
+                long timestamp = sample.getTimestamp();
+
+                // ConcurrentHashMap.compute is thread-safe and atomic per key
+                timestampToAggregated.compute(timestamp, (ts, bucket) -> aggregateSingleSample(bucket, sample));
+            }
+        });
+
+        // Create sorted samples - pre-allocate since we know the exact size
+        List<Sample> aggregatedSamples = new ArrayList<>(timestampToAggregated.size());
+        timestampToAggregated.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> aggregatedSamples.add(bucketToSample(entry.getKey(), entry.getValue())));
+
+        // Return a single time series with the provided labels
+        return new TimeSeries(
+            aggregatedSamples,
+            groupLabels != null ? groupLabels : ByteLabels.emptyLabels(),
+            firstSeries.getMinTimestamp(),
+            firstSeries.getMaxTimestamp(),
+            firstSeries.getStep(),
+            firstSeries.getAlias()
+        );
+    }
+
     @Override
     protected final InternalAggregation reduceGrouped(
         List<TimeSeriesProvider> aggregations,
@@ -155,8 +298,50 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         // Track outer HashMap allocation
         circuitBreakerConsumer.accept(RamUsageConstants.HASHMAP_SHALLOW_SIZE);
 
+        // Calculate total series count to determine if parallel processing should be used
+        int totalSeriesCount = 0;
+        int totalSamples = 0;
+        for (TimeSeriesProvider agg : aggregations) {
+            for (TimeSeries ts : agg.getTimeSeries()) {
+                totalSeriesCount++;
+                totalSamples += ts.getSamples().size();
+            }
+        }
+        int avgSamplesPerSeries = (totalSeriesCount == 0) ? 0 : (totalSamples / totalSeriesCount);
+
+        boolean useParallel = parallelConfig.shouldUseParallelProcessing(totalSeriesCount, avgSamplesPerSeries);
+
+        if (useParallel) {
+            logger.debug(
+                "Using parallel reduce for stage={}, totalSeries={}, avgSamples={}",
+                getName(),
+                totalSeriesCount,
+                avgSamplesPerSeries
+            );
+            return reduceGroupedParallel(aggregations, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
+        } else {
+            logger.debug(
+                "Using sequential reduce for stage={}, totalSeries={}, avgSamples={}",
+                getName(),
+                totalSeriesCount,
+                avgSamplesPerSeries
+            );
+            return reduceGroupedSequential(aggregations, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
+        }
+    }
+
+    /**
+     * Sequential reduce implementation (original logic).
+     */
+    private InternalAggregation reduceGroupedSequential(
+        List<TimeSeriesProvider> aggregations,
+        TimeSeriesProvider firstAgg,
+        TimeSeries firstTimeSeries,
+        boolean isFinalReduce,
+        LongConsumer circuitBreakerConsumer
+    ) {
         // Combine samples by group across all aggregations
-        Map<ByteLabels, Map<Long, A>> groupToTimestampSample = new HashMap<>();
+        Map<ByteLabels, Map<Long, A>> groupToTimestampBucket = new HashMap<>();
 
         for (TimeSeriesProvider aggregation : aggregations) {
             for (TimeSeries series : aggregation.getTimeSeries()) {
@@ -164,7 +349,7 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
                 ByteLabels groupLabels = extractGroupLabelsDirect(series);
 
                 // Track new group allocation
-                boolean isNewGroup = !groupToTimestampSample.containsKey(groupLabels);
+                boolean isNewGroup = !groupToTimestampBucket.containsKey(groupLabels);
                 if (isNewGroup) {
                     // Track: HashMap entry + labels + inner HashMap
                     circuitBreakerConsumer.accept(
@@ -172,26 +357,83 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
                     );
                 }
 
-                Map<Long, A> timestampToSample = groupToTimestampSample.computeIfAbsent(groupLabels, k -> new HashMap<>());
+                Map<Long, A> timestampToBucket = groupToTimestampBucket.computeIfAbsent(groupLabels, k -> new HashMap<>());
 
                 // Aggregate samples for this series into the group's timestamp map
-                aggregateSamplesIntoMap(series.getSamples(), timestampToSample, circuitBreakerConsumer);
+                aggregateSamplesIntoMap(series.getSamples(), timestampToBucket, circuitBreakerConsumer);
             }
         }
 
+        return finalizeReduction(groupToTimestampBucket, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
+    }
+
+    /**
+     * Parallel reduce implementation using ConcurrentHashMap for thread-safe aggregation.
+     * Uses the same {@link #aggregateSamplesIntoMap} logic as the sequential path so results
+     * are identical to main's reduceGrouped.
+     *
+     * <p>This method processes time series from multiple shards in parallel, significantly
+     * improving performance for large datasets at coordinator level when pushdown is disabled.</p>
+     */
+    private InternalAggregation reduceGroupedParallel(
+        List<TimeSeriesProvider> aggregations,
+        TimeSeriesProvider firstAgg,
+        TimeSeries firstTimeSeries,
+        boolean isFinalReduce,
+        LongConsumer circuitBreakerConsumer
+    ) {
+        // Use ConcurrentHashMap for thread-safe group aggregation
+        // Outer map: group labels -> timestamp map. Use compute() (not computeIfAbsent) so
+        // only one inner map is created per group when multiple threads hit the same key.
+        ConcurrentHashMap<ByteLabels, ConcurrentHashMap<Long, A>> groupToTimestampBucket = new ConcurrentHashMap<>();
+
+        // Process all aggregations in parallel
+        aggregations.parallelStream().forEach(aggregation -> {
+            for (TimeSeries series : aggregation.getTimeSeries()) {
+                ByteLabels groupLabels = extractGroupLabelsDirect(series);
+
+                // Get or create timestamp map for this group atomically (compute guarantees single map per group)
+                ConcurrentHashMap<Long, A> timestampToBucket = groupToTimestampBucket.compute(
+                    groupLabels,
+                    (k, existing) -> existing != null ? existing : new ConcurrentHashMap<>()
+                );
+
+                // Same aggregation logic as sequential path and main's reduceGrouped
+                aggregateSamplesIntoMap(series.getSamples(), timestampToBucket);
+            }
+        });
+
+        // Convert ConcurrentHashMap to regular HashMap for finalization
+        Map<ByteLabels, Map<Long, A>> regularMap = new HashMap<>(groupToTimestampBucket.size());
+        groupToTimestampBucket.forEach((groupLabels, timestampToBucket) -> regularMap.put(groupLabels, new HashMap<>(timestampToBucket)));
+
+        return finalizeReduction(regularMap, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
+    }
+
+    /**
+     * Finalize the reduction by creating time series from aggregated buckets.
+     * Shared logic for both sequential and parallel paths.
+     */
+    private InternalAggregation finalizeReduction(
+        Map<ByteLabels, Map<Long, A>> groupToTimestampBucket,
+        TimeSeriesProvider firstAgg,
+        TimeSeries firstTimeSeries,
+        boolean isFinalReduce,
+        LongConsumer circuitBreakerConsumer
+    ) {
         // Track result ArrayList allocation
         circuitBreakerConsumer.accept(SampleList.ARRAYLIST_OVERHEAD);
 
         // Create the final aggregated time series for each group
         // Pre-allocate result list since we know exactly how many groups we have
-        List<TimeSeries> resultTimeSeries = new ArrayList<>(groupToTimestampSample.size());
+        List<TimeSeries> resultTimeSeries = new ArrayList<>(groupToTimestampBucket.size());
 
-        for (Map.Entry<ByteLabels, Map<Long, A>> entry : groupToTimestampSample.entrySet()) {
+        for (Map.Entry<ByteLabels, Map<Long, A>> entry : groupToTimestampBucket.entrySet()) {
             ByteLabels groupLabels = entry.getKey();
-            Map<Long, A> timestampToSample = entry.getValue();
+            Map<Long, A> timestampToBucket = entry.getValue();
 
             // Pre-allocate samples list since we know exactly how many timestamps we have
-            SampleList sampleList = mapToSampleList(timestampToSample);
+            SampleList sampleList = mapToSampleList(timestampToBucket);
 
             Labels finalLabels = groupLabels.isEmpty() ? ByteLabels.emptyLabels() : groupLabels;
 
@@ -272,6 +514,20 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
                 // Track HashMap entry overhead for new timestamp (key + value)
                 circuitBreakerConsumer.accept(RamUsageEstimator.HASHTABLE_RAM_BYTES_PER_ENTRY + Long.BYTES + estimateStateSize());
             }
+        }
+    }
+
+    /**
+     * Helper method to aggregate samples into an existing timestamp map (parallel path, no per-entry circuit breaker tracking).
+     */
+    private void aggregateSamplesIntoMap(SampleList samples, Map<Long, A> timestampToSample) {
+        for (Sample sample : samples) {
+            // Skip NaN values - treat them as null/missing (MultiValueSample does not support getValue())
+            if (!(sample instanceof MultiValueSample) && Double.isNaN(sample.getValue())) {
+                continue;
+            }
+            long timestamp = sample.getTimestamp();
+            timestampToSample.compute(timestamp, (ts, a) -> aggregateSingleSample(a, sample));
         }
     }
 

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
@@ -243,12 +243,14 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         long timeRange = firstSeries.getMaxTimestamp() - firstSeries.getMinTimestamp();
         int expectedTimestamps = (int) (timeRange / firstSeries.getStep()) + 1;
 
-        // Each thread aggregates into a local map, then we merge (avoids per-key contention)
-        Map<Long, A> timestampToAggregated = groupSeries.parallelStream().map(series -> {
-            Map<Long, A> local = HashMap.newHashMap(expectedTimestamps);
-            aggregateSamplesIntoMap(series.getSamples(), local);
-            return local;
-        }).reduce(new HashMap<>(), this::mergeLocalMaps);
+        // Each thread accumulates into a thread-local map via collect (avoids per-key contention
+        // and unnecessary HashMap copying that reduce() would cause)
+        Map<Long, A> timestampToAggregated = groupSeries.parallelStream()
+            .collect(
+                () -> HashMap.newHashMap(expectedTimestamps),
+                (map, series) -> aggregateSamplesIntoMap(series.getSamples(), map),
+                this::combineLocalMaps
+            );
 
         // Create sorted samples - pre-allocate since we know the exact size
         List<Sample> aggregatedSamples = new ArrayList<>(timestampToAggregated.size());
@@ -350,8 +352,8 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
 
     /**
      * Parallel reduce implementation using thread-local aggregation then merge (same pattern as
-     * {@link #processGroupParallel}). Each thread aggregates one or more aggregations into a local
-     * {@code Map<ByteLabels, Map<Long, A>>}, then partial results are combined via {@link #mergeGroupMaps}.
+     * {@link #processGroupParallel}). Uses {@code collect()} so each thread accumulates into its own
+     * mutable map, then partial results are combined via {@link #combineGroupMaps}.
      * Avoids per-key contention by not sharing maps across threads.
      */
     private InternalAggregation reduceGroupedParallel(
@@ -361,44 +363,30 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         boolean isFinalReduce,
         LongConsumer circuitBreakerConsumer
     ) {
-        Map<ByteLabels, Map<Long, A>> groupToTimestampBucket = aggregations.parallelStream().map(aggregation -> {
-            Map<ByteLabels, Map<Long, A>> local = new HashMap<>();
+        Map<ByteLabels, Map<Long, A>> groupToTimestampBucket = aggregations.parallelStream().collect(HashMap::new, (local, aggregation) -> {
             for (TimeSeries series : aggregation.getTimeSeries()) {
                 ByteLabels groupLabels = extractGroupLabelsDirect(series);
                 Map<Long, A> timestampToBucket = local.computeIfAbsent(groupLabels, k -> new HashMap<>());
                 aggregateSamplesIntoMap(series.getSamples(), timestampToBucket);
             }
-            return local;
-        }).reduce(new HashMap<>(), this::mergeGroupMaps);
+        }, this::combineGroupMaps);
 
         return finalizeReduction(groupToTimestampBucket, firstAgg, firstTimeSeries, isFinalReduce, circuitBreakerConsumer);
     }
 
     /**
-     * Merge two group→timestamp maps (used when reducing parallel reduce partials).
-     * Must not mutate either argument so the combiner is safe when the same identity is
-     * reused in parallel (stream reduce can call combine(identity, p1) and combine(identity, p2)
-     * in different threads, then combine those results).
+     * Combine two group→timestamp maps by merging {@code source} into {@code target} (mutates target).
+     * Used as the combiner in {@code collect()} for parallel reduce.
      */
-    private Map<ByteLabels, Map<Long, A>> mergeGroupMaps(Map<ByteLabels, Map<Long, A>> a, Map<ByteLabels, Map<Long, A>> b) {
-        if (a.isEmpty()) {
-            return b;
-        }
-        if (b.isEmpty()) {
-            return a;
-        }
-        // Copy a so we never mutate the shared identity; then merge b into the copy
-        Map<ByteLabels, Map<Long, A>> result = new HashMap<>();
-        for (Entry<ByteLabels, Map<Long, A>> e : a.entrySet()) {
-            result.put(e.getKey(), new HashMap<>(e.getValue()));
-        }
-        for (Entry<ByteLabels, Map<Long, A>> e : b.entrySet()) {
-            Map<Long, A> resultTs = result.computeIfAbsent(e.getKey(), k -> new HashMap<>());
-            for (Entry<Long, A> be : e.getValue().entrySet()) {
-                resultTs.compute(be.getKey(), (ts, x) -> mergeBuckets(x, be.getValue(), ts));
+    private void combineGroupMaps(Map<ByteLabels, Map<Long, A>> target, Map<ByteLabels, Map<Long, A>> source) {
+        for (Entry<ByteLabels, Map<Long, A>> e : source.entrySet()) {
+            Map<Long, A> targetTs = target.get(e.getKey());
+            if (targetTs == null) {
+                target.put(e.getKey(), e.getValue());
+            } else {
+                combineLocalMaps(targetTs, e.getValue());
             }
         }
-        return result;
     }
 
     /**
@@ -500,21 +488,13 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
     }
 
     /**
-     * Merge two thread-local timestamp→bucket maps into one. Does not mutate either argument
-     * so the combiner is safe when used with parallel stream reduce (identity may be reused).
+     * Combine two thread-local timestamp→bucket maps by merging {@code source} into {@code target} (mutates target).
+     * Used as the combiner in {@code collect()} for parallel stream processing.
      */
-    private Map<Long, A> mergeLocalMaps(Map<Long, A> a, Map<Long, A> b) {
-        if (a.isEmpty()) {
-            return b;
+    private void combineLocalMaps(Map<Long, A> target, Map<Long, A> source) {
+        for (Entry<Long, A> e : source.entrySet()) {
+            target.compute(e.getKey(), (ts, x) -> mergeBuckets(x, e.getValue(), ts));
         }
-        if (b.isEmpty()) {
-            return a;
-        }
-        Map<Long, A> result = new HashMap<>(a);
-        for (Entry<Long, A> e : b.entrySet()) {
-            result.compute(e.getKey(), (ts, x) -> mergeBuckets(x, e.getValue(), ts));
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStage.java
@@ -203,14 +203,7 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         Map<Long, A> timestampToAggregated = HashMap.newHashMap(expectedTimestamps);
 
         for (TimeSeries series : groupSeries) {
-            for (Sample sample : series.getSamples()) {
-                // Skip NaN values - treat them as null/missing (MultiValueSample does not support getValue())
-                if (!(sample instanceof MultiValueSample) && Double.isNaN(sample.getValue())) {
-                    continue;
-                }
-                long timestamp = sample.getTimestamp();
-                timestampToAggregated.compute(timestamp, (ts, a) -> aggregateSingleSample(a, sample));
-            }
+            aggregateSamplesIntoMap(series.getSamples(), timestampToAggregated);
         }
         // Create sorted samples - pre-allocate since we know the exact size
         SampleList sampleList = mapToSampleList(timestampToAggregated);
@@ -256,18 +249,7 @@ public abstract class AbstractGroupingSampleStage<A> extends AbstractGroupingSta
         ConcurrentHashMap<Long, A> timestampToAggregated = new ConcurrentHashMap<>(expectedTimestamps, 0.9f);
 
         // Process all time series in parallel
-        groupSeries.parallelStream().forEach(series -> {
-            for (Sample sample : series.getSamples()) {
-                // Skip NaN values - treat them as null/missing
-                if (Double.isNaN(sample.getValue())) {
-                    continue;
-                }
-                long timestamp = sample.getTimestamp();
-
-                // ConcurrentHashMap.compute is thread-safe and atomic per key
-                timestampToAggregated.compute(timestamp, (ts, bucket) -> aggregateSingleSample(bucket, sample));
-            }
-        });
+        groupSeries.parallelStream().forEach(series -> aggregateSamplesIntoMap(series.getSamples(), timestampToAggregated));
 
         // Create sorted samples - pre-allocate since we know the exact size
         List<Sample> aggregatedSamples = new ArrayList<>(timestampToAggregated.size());

--- a/src/main/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfig.java
+++ b/src/main/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfig.java
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.stage;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.tsdb.TSDBPlugin;
+import org.opensearch.tsdb.lang.m3.stage.AbstractGroupingSampleStage;
+
+/**
+ * Configuration for parallel processing in grouping sample stages (sum, avg, min, max, count, etc.)
+ * at coordinator level.
+ *
+ * <p>This configuration is specifically for {@link AbstractGroupingSampleStage}
+ * and its subclasses. When pushdown is disabled, these stages execute on the coordinator node.
+ * For large datasets, parallel processing can improve performance by utilizing multiple CPU cores.</p>
+ *
+ * <h2>Applicable Stages:</h2>
+ * <ul>
+ *   <li>SumStage - parallel summation across time series</li>
+ *   <li>AvgStage - parallel averaging with SumCountSample</li>
+ *   <li>MinStage, MaxStage - parallel min/max computation</li>
+ *   <li>CountStage - parallel counting</li>
+ *   <li>Other stages extending AbstractGroupingSampleStage</li>
+ * </ul>
+ *
+ * <h2>Thread Safety:</h2>
+ * <p>Parallel processing uses {@link java.util.concurrent.ConcurrentHashMap} for
+ * thread-safe aggregation and {@link java.util.concurrent.ForkJoinPool} common pool
+ * for work-stealing parallel execution.</p>
+ *
+ * <h2>Settings:</h2>
+ * <p>Settings are defined in {@link TSDBPlugin}:</p>
+ * <ul>
+ *   <li>{@link TSDBPlugin#GROUPING_STAGE_PARALLEL_ENABLED}</li>
+ *   <li>{@link TSDBPlugin#GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD}</li>
+ *   <li>{@link TSDBPlugin#GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD}</li>
+ * </ul>
+ *
+ * <h2>Performance:</h2>
+ * <p>Parallel reduce can help when the coordinator merges many shards and total series/samples
+ * exceed thresholds. Benefit is limited by shard count (max parallelism) and can be reduced
+ * by contention when many series fall into few groups. Small reduces stay sequential to avoid
+ * overhead.</p>
+ *
+ * @param enabled whether parallel processing is enabled
+ * @param seriesThreshold minimum series count for parallel processing
+ * @param samplesThreshold minimum samples per series for parallel processing
+ * @see AbstractGroupingSampleStage
+ * @see TSDBPlugin
+ */
+public record ParallelProcessingConfig(boolean enabled, int seriesThreshold, int samplesThreshold) {
+
+    private static final Logger logger = LogManager.getLogger(ParallelProcessingConfig.class);
+
+    /**
+     * Initialize parallel processing configuration from cluster settings and register dynamic update listeners.
+     * Called from TSDBPlugin.createComponents() once per node startup.
+     *
+     * <p>This method:</p>
+     * <ol>
+     *   <li>Creates a ParallelProcessingConfig from current settings</li>
+     *   <li>Sets it on AbstractGroupingSampleStage</li>
+     *   <li>Registers listeners for dynamic setting updates</li>
+     * </ol>
+     *
+     * @param clusterSettings the cluster settings for registering dynamic listeners
+     * @param settings the current node settings
+     */
+    public static void initialize(ClusterSettings clusterSettings, Settings settings) {
+        // Initialize with current settings
+        ParallelProcessingConfig initialConfig = new ParallelProcessingConfig(
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.get(settings),
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.get(settings),
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.get(settings)
+        );
+        AbstractGroupingSampleStage.setParallelConfig(initialConfig);
+        logger.info(
+            "Initialized parallel processing config: enabled={}, seriesThreshold={}, samplesThreshold={}",
+            initialConfig.enabled(),
+            initialConfig.seriesThreshold(),
+            initialConfig.samplesThreshold()
+        );
+
+        // Register listeners for each setting - each listener updates only the changed field
+        // while preserving the other values from the current config
+        clusterSettings.addSettingsUpdateConsumer(TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED, ParallelProcessingConfig::updateEnabled);
+        clusterSettings.addSettingsUpdateConsumer(
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD,
+            ParallelProcessingConfig::updateSeriesThreshold
+        );
+        clusterSettings.addSettingsUpdateConsumer(
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD,
+            ParallelProcessingConfig::updateSamplesThreshold
+        );
+    }
+
+    /**
+     * Update the enabled setting while preserving other values.
+     * Package-private for testing.
+     */
+    static void updateEnabled(boolean newEnabled) {
+        ParallelProcessingConfig current = AbstractGroupingSampleStage.getParallelConfig();
+        ParallelProcessingConfig newConfig = new ParallelProcessingConfig(
+            newEnabled,
+            current.seriesThreshold(),
+            current.samplesThreshold()
+        );
+        AbstractGroupingSampleStage.setParallelConfig(newConfig);
+        logger.info("Updated parallel processing config: enabled={}", newEnabled);
+    }
+
+    /**
+     * Update the series threshold setting while preserving other values.
+     * Package-private for testing.
+     */
+    static void updateSeriesThreshold(int newThreshold) {
+        ParallelProcessingConfig current = AbstractGroupingSampleStage.getParallelConfig();
+        ParallelProcessingConfig newConfig = new ParallelProcessingConfig(current.enabled(), newThreshold, current.samplesThreshold());
+        AbstractGroupingSampleStage.setParallelConfig(newConfig);
+        logger.info("Updated parallel processing config: seriesThreshold={}", newThreshold);
+    }
+
+    /**
+     * Update the samples threshold setting while preserving other values.
+     * Package-private for testing.
+     */
+    static void updateSamplesThreshold(int newThreshold) {
+        ParallelProcessingConfig current = AbstractGroupingSampleStage.getParallelConfig();
+        ParallelProcessingConfig newConfig = new ParallelProcessingConfig(current.enabled(), current.seriesThreshold(), newThreshold);
+        AbstractGroupingSampleStage.setParallelConfig(newConfig);
+        logger.info("Updated parallel processing config: samplesThreshold={}", newThreshold);
+    }
+
+    /**
+     * Determine if parallel processing should be used for the given dataset in a grouping stage.
+     *
+     * @param seriesCount number of time series to process
+     * @param avgSamplesPerSeries average number of samples per series
+     * @return true if parallel processing should be used
+     */
+    public boolean shouldUseParallelProcessing(int seriesCount, int avgSamplesPerSeries) {
+        if (!enabled || seriesCount == 0) {
+            return false;
+        }
+
+        // Check both thresholds - need sufficient data volume for parallelism to be beneficial
+        return seriesCount >= seriesThreshold && avgSamplesPerSeries >= samplesThreshold;
+    }
+
+    /**
+     * Default configuration for when settings are not available.
+     * Uses conservative thresholds suitable for most workloads.
+     *
+     * @return default configuration
+     */
+    public static ParallelProcessingConfig defaultConfig() {
+        return new ParallelProcessingConfig(
+            true,  // parallel processing enabled
+            1000,  // series threshold
+            100    // samples threshold
+        );
+    }
+
+    /**
+     * Configuration that always uses sequential processing.
+     * Useful for testing or when parallel processing should be disabled.
+     *
+     * @return sequential-only configuration
+     */
+    public static ParallelProcessingConfig sequentialOnly() {
+        return new ParallelProcessingConfig(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Configuration that always uses parallel processing.
+     * Useful for testing parallel code paths.
+     *
+     * @return always-parallel configuration
+     */
+    public static ParallelProcessingConfig alwaysParallel() {
+        return new ParallelProcessingConfig(true, 0, 0);
+    }
+}

--- a/src/main/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfig.java
+++ b/src/main/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfig.java
@@ -32,9 +32,9 @@ import org.opensearch.tsdb.lang.m3.stage.AbstractGroupingSampleStage;
  * </ul>
  *
  * <h2>Thread Safety:</h2>
- * <p>Parallel processing uses {@link java.util.concurrent.ConcurrentHashMap} for
- * thread-safe aggregation and {@link java.util.concurrent.ForkJoinPool} common pool
- * for work-stealing parallel execution.</p>
+ * <p>Parallel processing uses thread-local aggregation, then merges partial
+ * results, avoiding lock contention. Work runs on {@link java.util.concurrent.ForkJoinPool}
+ * common pool.</p>
  *
  * <h2>Settings:</h2>
  * <p>Settings are defined in {@link TSDBPlugin}:</p>

--- a/src/test/java/org/opensearch/tsdb/TSDBPluginTests.java
+++ b/src/test/java/org/opensearch/tsdb/TSDBPluginTests.java
@@ -82,7 +82,7 @@ public class TSDBPluginTests extends OpenSearchTestCase {
         List<Setting<?>> settings = plugin.getSettings();
 
         assertNotNull("Settings list should not be null", settings);
-        assertThat("Should have 27 settings", settings, hasSize(27));
+        assertThat("Should have 30 settings", settings, hasSize(30));
 
         // Verify TSDB_ENGINE_ENABLED is present
         assertTrue("Should contain TSDB_ENGINE_ENABLED setting", settings.contains(TSDBPlugin.TSDB_ENGINE_ENABLED));
@@ -151,6 +151,18 @@ public class TSDBPluginTests extends OpenSearchTestCase {
         assertTrue(
             "Should contain TSDB_ENGINE_INTERNAL_TIME_SERIES_FORMAT",
             settings.contains(TSDBPlugin.TSDB_ENGINE_INTERNAL_TIME_SERIES_FORMAT)
+        );
+        assertTrue(
+            "Should contain GROUPING_STAGE_PARALLEL_ENABLED setting for grouping stages",
+            settings.contains(TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED)
+        );
+        assertTrue(
+            "Should contain GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD setting for grouping stages",
+            settings.contains(TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD)
+        );
+        assertTrue(
+            "Should contain GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD setting for grouping stages",
+            settings.contains(TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD)
         );
     }
 
@@ -395,6 +407,9 @@ public class TSDBPluginTests extends OpenSearchTestCase {
         allSettings.add(TSDBPlugin.TSDB_INGESTION_LAG_COORDINATOR_METRICS_ENABLED);
         allSettings.add(TSDBPlugin.TSDB_INGESTION_LAG_SEARCHABLE_METRICS_ENABLED);
         allSettings.add(TSDBPlugin.TSDB_ENGINE_INTERNAL_TIME_SERIES_FORMAT);
+        allSettings.add(TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED);
+        allSettings.add(TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD);
+        allSettings.add(TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD);
 
         ClusterSettings mockClusterSettings = new ClusterSettings(Settings.EMPTY, allSettings);
         when(mockClusterService.getClusterSettings()).thenReturn(mockClusterSettings);

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStageParallelTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStageParallelTests.java
@@ -1,0 +1,423 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.lang.m3.stage;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.tsdb.core.model.Labels;
+import org.opensearch.tsdb.core.model.Sample;
+import org.opensearch.tsdb.query.aggregator.InternalTimeSeries;
+import org.opensearch.tsdb.query.aggregator.TimeSeries;
+import org.opensearch.tsdb.query.aggregator.TimeSeriesProvider;
+import org.opensearch.tsdb.query.stage.ParallelProcessingConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.opensearch.tsdb.lang.m3.stage.StageTestUtils.createTimeSeries;
+
+/**
+ * Tests for parallel processing functionality in AbstractGroupingSampleStage.
+ * Verifies that parallel and sequential processing produce identical results.
+ *
+ * Note: Uses ThreadLeakScope.NONE because parallelStream() uses ForkJoinPool.commonPool()
+ * which creates worker threads that persist beyond test execution (with JVM-managed keepalive).
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class AbstractGroupingSampleStageParallelTests extends OpenSearchTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // Reset to default config before each test to ensure clean state
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.defaultConfig());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        // Always reset to default config after tests to avoid affecting other tests
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.defaultConfig());
+        super.tearDown();
+    }
+
+    /**
+     * Test that sequential and parallel processing produce identical results for sum.
+     */
+    public void testSequentialAndParallelProduceSameResultsForSum() {
+        // Create a large dataset that would trigger parallel processing
+        List<TimeSeries> largeInput = createLargeDataset(100, 200); // 100 series, 200 samples each
+
+        SumStage sumStage = new SumStage();
+
+        // Test with sequential processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.sequentialOnly());
+        List<TimeSeries> sequentialResult = sumStage.process(largeInput);
+
+        // Test with parallel processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
+        List<TimeSeries> parallelResult = sumStage.process(largeInput);
+
+        // Results should be identical
+        assertEquals(sequentialResult.size(), parallelResult.size());
+        assertEquals(1, sequentialResult.size());
+
+        TimeSeries seqTs = sequentialResult.get(0);
+        TimeSeries parTs = parallelResult.get(0);
+
+        assertEquals(seqTs.getSamples().size(), parTs.getSamples().size());
+
+        // Compare each sample
+        List<Sample> seqSamples = seqTs.getSamples().toList();
+        List<Sample> parSamples = parTs.getSamples().toList();
+        for (int i = 0; i < seqSamples.size(); i++) {
+            Sample seqSample = seqSamples.get(i);
+            Sample parSample = parSamples.get(i);
+            assertEquals(seqSample.getTimestamp(), parSample.getTimestamp());
+            assertEquals(seqSample.getValue(), parSample.getValue(), 0.0001);
+        }
+    }
+
+    /**
+     * Test that sequential and parallel processing produce identical results for avg.
+     */
+    public void testSequentialAndParallelProduceSameResultsForAvg() {
+        List<TimeSeries> largeInput = createLargeDataset(100, 200);
+
+        AvgStage avgStage = new AvgStage();
+
+        // Test with sequential processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.sequentialOnly());
+        List<TimeSeries> sequentialResult = avgStage.process(largeInput);
+
+        // Test with parallel processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
+        List<TimeSeries> parallelResult = avgStage.process(largeInput);
+
+        // Results should be identical
+        assertEquals(sequentialResult.size(), parallelResult.size());
+        assertEquals(1, sequentialResult.size());
+
+        TimeSeries seqTs = sequentialResult.get(0);
+        TimeSeries parTs = parallelResult.get(0);
+
+        assertEquals(seqTs.getSamples().size(), parTs.getSamples().size());
+
+        // Compare each sample
+        List<Sample> seqSamples = seqTs.getSamples().toList();
+        List<Sample> parSamples = parTs.getSamples().toList();
+        for (int i = 0; i < seqSamples.size(); i++) {
+            Sample seqSample = seqSamples.get(i);
+            Sample parSample = parSamples.get(i);
+            assertEquals(seqSample.getTimestamp(), parSample.getTimestamp());
+            assertEquals(seqSample.getValue(), parSample.getValue(), 0.0001);
+        }
+    }
+
+    /**
+     * Test that grouped aggregation works correctly in parallel.
+     */
+    public void testParallelProcessingWithGrouping() {
+        // Create data with multiple groups
+        List<TimeSeries> input = new ArrayList<>();
+        for (int g = 0; g < 5; g++) {
+            for (int s = 0; s < 50; s++) {
+                List<Double> values = new ArrayList<>();
+                for (int v = 0; v < 100; v++) {
+                    values.add((double) (g * 100 + s + v));
+                }
+                input.add(createTimeSeries("ts_" + g + "_" + s, Map.of("group", "group" + g), values));
+            }
+        }
+
+        SumStage sumStage = new SumStage("group");
+
+        // Test with sequential processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.sequentialOnly());
+        List<TimeSeries> sequentialResult = sumStage.process(input);
+
+        // Test with parallel processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
+        List<TimeSeries> parallelResult = sumStage.process(input);
+
+        // Should have 5 groups
+        assertEquals(5, sequentialResult.size());
+        assertEquals(5, parallelResult.size());
+
+        // Sort by group label for comparison
+        sequentialResult.sort((a, b) -> a.getLabels().get("group").compareTo(b.getLabels().get("group")));
+        parallelResult.sort((a, b) -> a.getLabels().get("group").compareTo(b.getLabels().get("group")));
+
+        // Compare each group
+        for (int g = 0; g < 5; g++) {
+            TimeSeries seqTs = sequentialResult.get(g);
+            TimeSeries parTs = parallelResult.get(g);
+
+            assertEquals(seqTs.getLabels().get("group"), parTs.getLabels().get("group"));
+            assertEquals(seqTs.getSamples().size(), parTs.getSamples().size());
+
+            List<Sample> seqSamples = seqTs.getSamples().toList();
+            List<Sample> parSamples = parTs.getSamples().toList();
+            for (int i = 0; i < seqSamples.size(); i++) {
+                Sample seqSample = seqSamples.get(i);
+                Sample parSample = parSamples.get(i);
+                assertEquals(seqSample.getTimestamp(), parSample.getTimestamp());
+                assertEquals(seqSample.getValue(), parSample.getValue(), 0.0001);
+            }
+        }
+    }
+
+    /**
+     * Test that reduce operations work correctly in parallel.
+     */
+    public void testParallelReduce() {
+        // Create multiple aggregations simulating data from different shards
+        List<TimeSeriesProvider> aggregations = new ArrayList<>();
+        for (int shard = 0; shard < 10; shard++) {
+            List<TimeSeries> shardData = new ArrayList<>();
+            for (int s = 0; s < 50; s++) {
+                List<Double> values = new ArrayList<>();
+                for (int v = 0; v < 100; v++) {
+                    values.add((double) (shard * 100 + s + v));
+                }
+                shardData.add(createTimeSeries("ts_" + shard + "_" + s, Map.of(), values));
+            }
+            aggregations.add(new InternalTimeSeries("shard" + shard, shardData, Map.of()));
+        }
+
+        SumStage sumStage = new SumStage();
+
+        // Test with sequential processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.sequentialOnly());
+        InternalAggregation sequentialResult = sumStage.reduce(aggregations, true);
+
+        // Test with parallel processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
+        InternalAggregation parallelResult = sumStage.reduce(aggregations, true);
+
+        // Compare results
+        TimeSeriesProvider seqProvider = (TimeSeriesProvider) sequentialResult;
+        TimeSeriesProvider parProvider = (TimeSeriesProvider) parallelResult;
+
+        assertEquals(seqProvider.getTimeSeries().size(), parProvider.getTimeSeries().size());
+        assertEquals(1, seqProvider.getTimeSeries().size());
+
+        TimeSeries seqTs = seqProvider.getTimeSeries().get(0);
+        TimeSeries parTs = parProvider.getTimeSeries().get(0);
+
+        assertEquals(seqTs.getSamples().size(), parTs.getSamples().size());
+
+        List<Sample> seqSamples = seqTs.getSamples().toList();
+        List<Sample> parSamples = parTs.getSamples().toList();
+        for (int i = 0; i < seqSamples.size(); i++) {
+            Sample seqSample = seqSamples.get(i);
+            Sample parSample = parSamples.get(i);
+            assertEquals(seqSample.getTimestamp(), parSample.getTimestamp());
+            assertEquals(seqSample.getValue(), parSample.getValue(), 0.0001);
+        }
+    }
+
+    /**
+     * Test that config thresholds work correctly.
+     */
+    public void testConfigThresholdsAreRespected() {
+        ParallelProcessingConfig config = new ParallelProcessingConfig(true, 100, 50);
+
+        // Below both thresholds - should use sequential
+        assertFalse(config.shouldUseParallelProcessing(50, 30));
+
+        // Above series threshold but below samples threshold - should use sequential
+        assertFalse(config.shouldUseParallelProcessing(200, 30));
+
+        // Below series threshold but above samples threshold - should use sequential
+        assertFalse(config.shouldUseParallelProcessing(50, 100));
+
+        // Above both thresholds - should use parallel
+        assertTrue(config.shouldUseParallelProcessing(200, 100));
+    }
+
+    /**
+     * Test that disabled config prevents parallel processing.
+     */
+    public void testDisabledConfigPreventsParallel() {
+        ParallelProcessingConfig config = new ParallelProcessingConfig(false, 0, 0);
+
+        // Even with thresholds at 0, disabled should prevent parallel
+        assertFalse(config.shouldUseParallelProcessing(1000, 1000));
+    }
+
+    /**
+     * Test parallel processing with NaN values.
+     */
+    public void testParallelProcessingWithNaNValues() {
+        List<TimeSeries> input = new ArrayList<>();
+        for (int s = 0; s < 100; s++) {
+            List<Double> values = new ArrayList<>();
+            for (int v = 0; v < 100; v++) {
+                // Sprinkle some NaN values
+                if (v % 10 == 0 && s % 5 == 0) {
+                    values.add(Double.NaN);
+                } else {
+                    values.add((double) (s + v));
+                }
+            }
+            input.add(createTimeSeries("ts_" + s, Map.of(), values));
+        }
+
+        SumStage sumStage = new SumStage();
+
+        // Test with sequential processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.sequentialOnly());
+        List<TimeSeries> sequentialResult = sumStage.process(input);
+
+        // Test with parallel processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
+        List<TimeSeries> parallelResult = sumStage.process(input);
+
+        // Results should be identical
+        assertEquals(sequentialResult.size(), parallelResult.size());
+
+        TimeSeries seqTs = sequentialResult.get(0);
+        TimeSeries parTs = parallelResult.get(0);
+
+        assertEquals(seqTs.getSamples().size(), parTs.getSamples().size());
+
+        List<Sample> seqSamples = seqTs.getSamples().toList();
+        List<Sample> parSamples = parTs.getSamples().toList();
+        for (int i = 0; i < seqSamples.size(); i++) {
+            Sample seqSample = seqSamples.get(i);
+            Sample parSample = parSamples.get(i);
+            assertEquals(seqSample.getTimestamp(), parSample.getTimestamp());
+            assertEquals(seqSample.getValue(), parSample.getValue(), 0.0001);
+        }
+    }
+
+    /**
+     * Test concurrent access safety with many threads.
+     * This test verifies that the parallel implementation handles concurrent modifications correctly.
+     */
+    public void testConcurrentAccessSafety() {
+        // Create dataset with overlapping timestamps across series to stress concurrent access
+        List<TimeSeries> input = new ArrayList<>();
+        for (int s = 0; s < 500; s++) {
+            List<Double> values = new ArrayList<>();
+            for (int v = 0; v < 100; v++) {
+                values.add(1.0); // All same value makes sum easy to verify
+            }
+            input.add(createTimeSeries("ts_" + s, Map.of(), values));
+        }
+
+        SumStage sumStage = new SumStage();
+
+        // Force parallel processing
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
+
+        // Run multiple times to increase chance of catching race conditions
+        for (int run = 0; run < 10; run++) {
+            List<TimeSeries> result = sumStage.process(input);
+
+            assertEquals(1, result.size());
+            TimeSeries ts = result.get(0);
+
+            // Each timestamp should have sum of 500 (500 series * 1.0 value)
+            for (Sample sample : ts.getSamples()) {
+                assertEquals("Sum should be 500 for all timestamps", 500.0, sample.getValue(), 0.0001);
+            }
+        }
+    }
+
+    /**
+     * Test get and set parallel config on AbstractGroupingSampleStage.
+     */
+    public void testGetAndSetParallelConfig() {
+        // Set a custom config
+        ParallelProcessingConfig customConfig = new ParallelProcessingConfig(false, 500, 200);
+        AbstractGroupingSampleStage.setParallelConfig(customConfig);
+
+        // Verify getParallelConfig returns the same config
+        ParallelProcessingConfig retrieved = AbstractGroupingSampleStage.getParallelConfig();
+        assertEquals(customConfig, retrieved);
+        assertFalse(retrieved.enabled());
+        assertEquals(500, retrieved.seriesThreshold());
+        assertEquals(200, retrieved.samplesThreshold());
+
+        // Reset and verify
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.defaultConfig());
+        retrieved = AbstractGroupingSampleStage.getParallelConfig();
+        assertTrue(retrieved.enabled());
+        assertEquals(1000, retrieved.seriesThreshold());
+        assertEquals(100, retrieved.samplesThreshold());
+    }
+
+    /**
+     * Test processGroup with empty list throws.
+     */
+    public void testProcessGroupWithEmptyListThrows() {
+        ExposeForTestStage stage = new ExposeForTestStage();
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> stage.exposeProcessGroup(Collections.emptyList(), null)
+        );
+        assertTrue(e.getMessage().contains("must not be empty"));
+    }
+
+    /**
+     * Test reduceGrouped with aggregations that have no time series (totalSeriesCount=0).
+     * Covers the branch where avgSamplesPerSeries is 0 and sequential path is used.
+     */
+    public void testReduceGroupedWithEmptyAggregations() {
+        TimeSeries dummySeries = createTimeSeries("dummy", Map.of(), List.of(1.0));
+        TimeSeriesProvider emptyAgg = new InternalTimeSeries("empty", Collections.emptyList(), Map.of());
+        List<TimeSeriesProvider> aggregations = List.of(emptyAgg);
+
+        ExposeForTestStage stage = new ExposeForTestStage();
+        InternalAggregation result = stage.exposeReduceGrouped(aggregations, emptyAgg, dummySeries, false);
+
+        assertNotNull(result);
+        TimeSeriesProvider provider = (TimeSeriesProvider) result;
+        assertEquals(0, provider.getTimeSeries().size());
+    }
+
+    /**
+     * Create a large dataset for testing parallel processing.
+     *
+     * @param numSeries number of time series
+     * @param samplesPerSeries number of samples per series
+     * @return list of time series
+     */
+    private List<TimeSeries> createLargeDataset(int numSeries, int samplesPerSeries) {
+        List<TimeSeries> result = new ArrayList<>();
+        for (int s = 0; s < numSeries; s++) {
+            List<Double> values = new ArrayList<>();
+            for (int v = 0; v < samplesPerSeries; v++) {
+                values.add((double) (s * samplesPerSeries + v));
+            }
+            result.add(createTimeSeries("series_" + s, Map.of(), values));
+        }
+        return result;
+    }
+
+    /** Test-only stage that exposes protected methods for coverage tests (avoids forbidden reflection). */
+    private static final class ExposeForTestStage extends SumStage {
+        TimeSeries exposeProcessGroup(List<TimeSeries> groupSeries, Labels groupLabels) {
+            return processGroup(groupSeries, groupLabels);
+        }
+
+        InternalAggregation exposeReduceGrouped(
+            List<TimeSeriesProvider> aggregations,
+            TimeSeriesProvider firstAgg,
+            TimeSeries firstTimeSeries,
+            boolean isFinalReduce
+        ) {
+            return reduceGrouped(aggregations, firstAgg, firstTimeSeries, isFinalReduce);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStageParallelTests.java
+++ b/src/test/java/org/opensearch/tsdb/lang/m3/stage/AbstractGroupingSampleStageParallelTests.java
@@ -215,11 +215,11 @@ public class AbstractGroupingSampleStageParallelTests extends OpenSearchTestCase
 
         // Test with sequential processing
         AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.sequentialOnly());
-        InternalAggregation sequentialResult = sumStage.reduce(aggregations, true);
+        InternalAggregation sequentialResult = sumStage.reduce(aggregations, true, ignored -> {});
 
         // Test with parallel processing
         AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.alwaysParallel());
-        InternalAggregation parallelResult = sumStage.reduce(aggregations, true);
+        InternalAggregation parallelResult = sumStage.reduce(aggregations, true, ignored -> {});
 
         // Compare results
         TimeSeriesProvider seqProvider = (TimeSeriesProvider) sequentialResult;
@@ -435,7 +435,7 @@ public class AbstractGroupingSampleStageParallelTests extends OpenSearchTestCase
             TimeSeries firstTimeSeries,
             boolean isFinalReduce
         ) {
-            return reduceGrouped(aggregations, firstAgg, firstTimeSeries, isFinalReduce);
+            return reduceGrouped(aggregations, firstAgg, firstTimeSeries, isFinalReduce, ignored -> {});
         }
     }
 }

--- a/src/test/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfigTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfigTests.java
@@ -84,18 +84,22 @@ public class ParallelProcessingConfigTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test setting default values match defaultConfig().
+     * Test setting default values when using empty settings.
+     * Plugin defaults are conservative (parallel disabled by default); series/samples thresholds match defaultConfig().
      */
     public void testSettingDefaultsMatchDefaultConfig() {
         Settings emptySettings = Settings.EMPTY;
 
-        assertEquals(ParallelProcessingConfig.defaultConfig().enabled(), TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.get(emptySettings));
         assertEquals(
-            ParallelProcessingConfig.defaultConfig().seriesThreshold(),
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.getDefault(emptySettings),
+            TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.get(emptySettings)
+        );
+        assertEquals(
+            (int) TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.getDefault(emptySettings),
             (int) TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.get(emptySettings)
         );
         assertEquals(
-            ParallelProcessingConfig.defaultConfig().samplesThreshold(),
+            (int) TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.getDefault(emptySettings),
             (int) TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.get(emptySettings)
         );
     }
@@ -108,7 +112,7 @@ public class ParallelProcessingConfigTests extends OpenSearchTestCase {
         assertTrue("Series threshold setting should be dynamic", TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.isDynamic());
         assertTrue("Samples threshold setting should be dynamic", TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.isDynamic());
 
-        assertEquals(Boolean.TRUE, TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.getDefault(Settings.EMPTY));
+        assertEquals(Boolean.FALSE, TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.getDefault(Settings.EMPTY));
         assertEquals(Integer.valueOf(1000), TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.getDefault(Settings.EMPTY));
         assertEquals(Integer.valueOf(100), TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.getDefault(Settings.EMPTY));
     }

--- a/src/test/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfigTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/stage/ParallelProcessingConfigTests.java
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.stage;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.tsdb.TSDBPlugin;
+import org.opensearch.tsdb.lang.m3.stage.AbstractGroupingSampleStage;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests for ParallelProcessingConfig.
+ */
+public class ParallelProcessingConfigTests extends OpenSearchTestCase {
+
+    /**
+     * Test default configuration values.
+     */
+    public void testDefaultConfig() {
+        ParallelProcessingConfig config = ParallelProcessingConfig.defaultConfig();
+
+        assertTrue("Default config should be enabled", config.enabled());
+        assertEquals("Default series threshold should be 1000", 1000, config.seriesThreshold());
+        assertEquals("Default samples threshold should be 100", 100, config.samplesThreshold());
+    }
+
+    /**
+     * Test sequential-only configuration.
+     */
+    public void testSequentialOnlyConfig() {
+        ParallelProcessingConfig config = ParallelProcessingConfig.sequentialOnly();
+
+        assertFalse("Sequential-only config should be disabled", config.enabled());
+        assertFalse("Disabled config should not use parallel", config.shouldUseParallelProcessing(Integer.MAX_VALUE, Integer.MAX_VALUE));
+    }
+
+    /**
+     * Test always-parallel configuration.
+     */
+    public void testAlwaysParallelConfig() {
+        ParallelProcessingConfig config = ParallelProcessingConfig.alwaysParallel();
+
+        assertTrue("Always-parallel config should be enabled", config.enabled());
+        assertEquals("Series threshold should be 0", 0, config.seriesThreshold());
+        assertEquals("Samples threshold should be 0", 0, config.samplesThreshold());
+        assertTrue("Should use parallel even with minimal data", config.shouldUseParallelProcessing(1, 1));
+    }
+
+    /**
+     * Test threshold logic - both thresholds must be met for parallel processing.
+     */
+    public void testThresholdLogic() {
+        ParallelProcessingConfig config = new ParallelProcessingConfig(true, 100, 50);
+
+        // Below both thresholds
+        assertFalse("Should not use parallel when below both thresholds", config.shouldUseParallelProcessing(50, 25));
+
+        // Above series, below samples
+        assertFalse("Should not use parallel when below samples threshold", config.shouldUseParallelProcessing(200, 25));
+
+        // Below series, above samples
+        assertFalse("Should not use parallel when below series threshold", config.shouldUseParallelProcessing(50, 100));
+
+        // Above both thresholds
+        assertTrue("Should use parallel when above both thresholds", config.shouldUseParallelProcessing(200, 100));
+
+        // Exactly at thresholds
+        assertTrue("Should use parallel at exactly thresholds", config.shouldUseParallelProcessing(100, 50));
+
+        // Edge cases: zero and negative values
+        assertFalse(config.shouldUseParallelProcessing(0, 0));
+        assertFalse(config.shouldUseParallelProcessing(-1, -1));
+
+        // Large values
+        assertTrue(config.shouldUseParallelProcessing(Integer.MAX_VALUE, Integer.MAX_VALUE));
+    }
+
+    /**
+     * Test setting default values match defaultConfig().
+     */
+    public void testSettingDefaultsMatchDefaultConfig() {
+        Settings emptySettings = Settings.EMPTY;
+
+        assertEquals(ParallelProcessingConfig.defaultConfig().enabled(), TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.get(emptySettings));
+        assertEquals(
+            ParallelProcessingConfig.defaultConfig().seriesThreshold(),
+            (int) TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.get(emptySettings)
+        );
+        assertEquals(
+            ParallelProcessingConfig.defaultConfig().samplesThreshold(),
+            (int) TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.get(emptySettings)
+        );
+    }
+
+    /**
+     * Test setting definitions have correct properties.
+     */
+    public void testSettingProperties() {
+        assertTrue("Enabled setting should be dynamic", TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.isDynamic());
+        assertTrue("Series threshold setting should be dynamic", TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.isDynamic());
+        assertTrue("Samples threshold setting should be dynamic", TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.isDynamic());
+
+        assertEquals(Boolean.TRUE, TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED.getDefault(Settings.EMPTY));
+        assertEquals(Integer.valueOf(1000), TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD.getDefault(Settings.EMPTY));
+        assertEquals(Integer.valueOf(100), TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD.getDefault(Settings.EMPTY));
+    }
+
+    /**
+     * Test initialize method and dynamic setting updates via ClusterSettings.applySettings().
+     */
+    public void testInitializeAndDynamicUpdates() {
+        // Create initial settings
+        Settings initialSettings = Settings.builder()
+            .put("tsdb_engine.query.grouping_stage.parallel_processing.enabled", true)
+            .put("tsdb_engine.query.grouping_stage.parallel_processing.series_threshold", 1000)
+            .put("tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold", 100)
+            .build();
+
+        // Create ClusterSettings with all our settings registered
+        Set<org.opensearch.common.settings.Setting<?>> settingsSet = new HashSet<>();
+        settingsSet.add(TSDBPlugin.GROUPING_STAGE_PARALLEL_ENABLED);
+        settingsSet.add(TSDBPlugin.GROUPING_STAGE_PARALLEL_SERIES_THRESHOLD);
+        settingsSet.add(TSDBPlugin.GROUPING_STAGE_PARALLEL_SAMPLES_THRESHOLD);
+
+        ClusterSettings clusterSettings = new ClusterSettings(initialSettings, settingsSet);
+
+        // Initialize - this registers the listeners
+        ParallelProcessingConfig.initialize(clusterSettings, initialSettings);
+
+        // Verify initial state
+        ParallelProcessingConfig config = AbstractGroupingSampleStage.getParallelConfig();
+        assertTrue("Initial: enabled should be true", config.enabled());
+        assertEquals("Initial: series threshold should be 1000", 1000, config.seriesThreshold());
+        assertEquals("Initial: samples threshold should be 100", 100, config.samplesThreshold());
+
+        // Dynamically update enabled to false
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.enabled", false)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.series_threshold", 1000)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold", 100)
+                .build()
+        );
+        config = AbstractGroupingSampleStage.getParallelConfig();
+        assertFalse("After update: enabled should be false", config.enabled());
+
+        // Dynamically update series threshold
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.enabled", false)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.series_threshold", 5000)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold", 100)
+                .build()
+        );
+        config = AbstractGroupingSampleStage.getParallelConfig();
+        assertEquals("After update: series threshold should be 5000", 5000, config.seriesThreshold());
+
+        // Dynamically update samples threshold
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.enabled", false)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.series_threshold", 5000)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold", 500)
+                .build()
+        );
+        config = AbstractGroupingSampleStage.getParallelConfig();
+        assertEquals("After update: samples threshold should be 500", 500, config.samplesThreshold());
+
+        // Re-enable parallel processing
+        clusterSettings.applySettings(
+            Settings.builder()
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.enabled", true)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.series_threshold", 5000)
+                .put("tsdb_engine.query.grouping_stage.parallel_processing.samples_threshold", 500)
+                .build()
+        );
+        config = AbstractGroupingSampleStage.getParallelConfig();
+        assertTrue("After re-enable: enabled should be true", config.enabled());
+
+        // Reset
+        AbstractGroupingSampleStage.setParallelConfig(ParallelProcessingConfig.defaultConfig());
+    }
+}


### PR DESCRIPTION
### Description
- Adds parallel processing support to `AbstractGroupingSampleStage` for both `processGroup` and `reduceGrouped` operations, only for the coordinator processing
- Introduces `ParallelProcessingConfig` with configurable thresholds 
- Auto-selects sequential vs parallel based on dataset size to avoid thread overhead on small datasets


## Performance Impact
- 2x speedup when pushdown is disabled and expecting more performance improvements for high cardinality queries
- No impact on small datasets (stays sequential)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
