### PR TITLE
Add reference counting support for index commit snapshots and synchronize indexWriter usage in CCI

### DIFF
--- a/src/main/java/org/opensearch/index/engine/TSDBEngine.java
+++ b/src/main/java/org/opensearch/index/engine/TSDBEngine.java
@@ -915,9 +915,9 @@ public class TSDBEngine extends Engine {
      */
     @Override
     public GatedCloseable<IndexCommit> acquireSafeIndexCommit() throws EngineException {
+        List<Runnable> releaseActions = new ArrayList<>();
         try {
             List<IndexCommit> snapshots = new ArrayList<>();
-            List<Runnable> releaseActions = new ArrayList<>();
 
             // Snapshot live index
             LiveSeriesIndex.SnapshotResult liveIndexSnapshotResult = head.getLiveSeriesIndex().snapshotWithReleaseAction();
@@ -959,6 +959,14 @@ public class TSDBEngine extends Engine {
             return new GatedCloseable<>(compositeCommit, compositeCommit::releaseSnapshots);
 
         } catch (Exception e) {
+            // release acquired index commit snapshots by executing the release actions obtained so far
+            for (Runnable releaseAction : releaseActions) {
+                try {
+                    releaseAction.run();
+                } catch (Exception releaseException) {
+                    logger.warn("Failed to release snapshot during acquireSafeIndexCommit cleanup", releaseException);
+                }
+            }
             throw new EngineException(shardId, "Failed to acquire safe index commit", e);
         }
     }

--- a/src/main/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndex.java
+++ b/src/main/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndex.java
@@ -32,6 +32,7 @@ import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
@@ -58,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -75,6 +77,9 @@ public class ClosedChunkIndex implements Closeable {
     private final LabelStorageType labelStorageType;
     private final SeriesMetadataManager metadataManager;
     private final AtomicLong pendingSampleCount = new AtomicLong(0);
+    private final ReentrantReadWriteLock indexWriterLock = new ReentrantReadWriteLock();
+    private final ReleasableLock readLock = new ReleasableLock(indexWriterLock.readLock());
+    private final ReleasableLock writeLock = new ReleasableLock(indexWriterLock.writeLock());
     private IndexWriter indexWriter;
 
     /**
@@ -124,7 +129,7 @@ public class ClosedChunkIndex implements Closeable {
             iwc.setIndexSort(indexSort);
 
             indexWriter = new IndexWriter(directory, iwc);
-            this.metadataManager = new SeriesMetadataManager(directory, indexWriter, snapshotDeletionPolicy);
+            this.metadataManager = new SeriesMetadataManager(directory, () -> this.indexWriter, snapshotDeletionPolicy);
             directoryReaderManager = new ReaderManager(DirectoryReader.open(indexWriter));
             path = dir;
         } catch (IOException e) {
@@ -174,7 +179,9 @@ public class ClosedChunkIndex implements Closeable {
         // Uses OpenSearch's RangeType.LONG encoding (VarInt format for compact storage)
         doc.add(new BinaryDocValuesField(Constants.IndexSchema.TIMESTAMP_RANGE, TimestampRangeEncoding.encodeRange(minTs, maxTs)));
 
-        indexWriter.addDocument(doc);
+        try (ReleasableLock ignored = readLock.acquire()) {
+            indexWriter.addDocument(doc);
+        }
 
         pendingSampleCount.addAndGet(chunk.numSamples());
 
@@ -210,7 +217,7 @@ public class ClosedChunkIndex implements Closeable {
      * @param maxNumSegments the maximum number of segments to merge down to
      */
     public void forceMerge(int maxNumSegments) {
-        try {
+        try (ReleasableLock ignored = readLock.acquire()) {
             indexWriter.forceMerge(maxNumSegments);
         } catch (Exception e) {
             throw ExceptionsHelper.convertToRuntime(e);
@@ -253,7 +260,7 @@ public class ClosedChunkIndex implements Closeable {
     }
 
     public void commit() {
-        try {
+        try (ReleasableLock ignored = readLock.acquire()) {
             indexWriter.commit();
         } catch (Exception e) {
             throw ExceptionsHelper.convertToRuntime(e);
@@ -266,7 +273,9 @@ public class ClosedChunkIndex implements Closeable {
      * @throws IOException if anything goes wrong while deleting the files.
      */
     public void deleteUnusedFiles() throws IOException {
-        indexWriter.deleteUnusedFiles();
+        try (ReleasableLock ignored = readLock.acquire()) {
+            indexWriter.deleteUnusedFiles();
+        }
     }
 
     /**
@@ -291,7 +300,7 @@ public class ClosedChunkIndex implements Closeable {
      * @param liveSeries the map of seriesRef to corresponding max mmap timestamps.
      */
     public void commitWithMetadata(Map<Long, Long> liveSeries) {
-        try {
+        try (ReleasableLock ignored = readLock.acquire()) {
             metadataManager.commitWithMetadata(liveSeries, Map.of(COMMIT_DATA_SAMPLE_COUNT_KEY, Long.toString(getTotalSampleCount())));
         } catch (IOException e) {
             throw new RuntimeException("Failed to commit with metadata", e);
@@ -304,7 +313,7 @@ public class ClosedChunkIndex implements Closeable {
      * @param consumer BiConsumer to accept seriesRef(Long) and ts(Long).
      */
     public void applyLiveSeriesMetaData(BiConsumer<Long, Long> consumer) {
-        try {
+        try (ReleasableLock ignored = readLock.acquire()) {
             metadataManager.applyMetadata(consumer);
         } catch (IOException e) {
             throw ExceptionsHelper.convertToRuntime(e);
@@ -318,7 +327,9 @@ public class ClosedChunkIndex implements Closeable {
      * @throws IOException if snapshot fails
      */
     public IndexCommit snapshot() throws IOException {
-        return metadataManager.snapshot();
+        try (ReleasableLock ignored = readLock.acquire()) {
+            return metadataManager.snapshot();
+        }
     }
 
     /**
@@ -328,7 +339,9 @@ public class ClosedChunkIndex implements Closeable {
      * @throws IOException if release fails
      */
     public void release(IndexCommit snapshot) throws IOException {
-        metadataManager.release(snapshot);
+        try (ReleasableLock ignored = readLock.acquire()) {
+            metadataManager.release(snapshot);
+        }
     }
 
     /**
@@ -385,15 +398,19 @@ public class ClosedChunkIndex implements Closeable {
      * @throws IOException IOException will be thrown if the indexWriter can not be re-opened.
      */
     public void copyTo(ClosedChunkIndex other) throws IOException {
-        var isWriterOpen = indexWriter.isOpen();
-        try {
-            this.indexWriter.close();
-            other.indexWriter.addIndexes(this.directory);
-        } finally {
-            IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
-            iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
-            if (isWriterOpen) {
-                indexWriter = new IndexWriter(directory, iwc);
+        try (ReleasableLock ignored = writeLock.acquire()) {
+            var isWriterOpen = indexWriter.isOpen();
+            try {
+                this.indexWriter.close();
+                other.indexWriter.addIndexes(this.directory);
+            } finally {
+                // Reopen the writer if it was previously open, so the source index remains usable after copy, even if addIndexes failed.
+                // The write lock is released only after the new writer is in place.
+                IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
+                iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
+                if (isWriterOpen) {
+                    this.indexWriter = new IndexWriter(directory, iwc);
+                }
             }
         }
     }

--- a/src/main/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndex.java
+++ b/src/main/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndex.java
@@ -78,7 +78,9 @@ public class ClosedChunkIndex implements Closeable {
     private final SeriesMetadataManager metadataManager;
     private final AtomicLong pendingSampleCount = new AtomicLong(0);
     private final ReentrantReadWriteLock indexWriterLock = new ReentrantReadWriteLock();
+    // readLock is used to indicate the indexWriter is being used
     private final ReleasableLock readLock = new ReleasableLock(indexWriterLock.readLock());
+    // writeLock is used to indicate indexWriter lifecycle changes are in-progress and indexWriter usage must wait
     private final ReleasableLock writeLock = new ReleasableLock(indexWriterLock.writeLock());
     private IndexWriter indexWriter;
 

--- a/src/main/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndexManager.java
+++ b/src/main/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndexManager.java
@@ -35,6 +35,7 @@ import org.opensearch.tsdb.core.head.MemSeries;
 import org.opensearch.tsdb.core.index.ReaderManagerWithMetadata;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.retention.Retention;
+import org.opensearch.tsdb.core.utils.KeyedRefCounter;
 import org.opensearch.tsdb.core.utils.Time;
 import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.tsdb.metrics.TSDBMetrics;
@@ -54,7 +55,6 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -105,7 +105,7 @@ public class ClosedChunkIndexManager implements Closeable {
     private final Compaction compaction;
     private final Set<ClosedChunkIndex> indexesUndergoingCompaction;
     private final Set<ClosedChunkIndex> pendingClosureIndexes;
-    private final Set<ClosedChunkIndex> snapshottedIndexes = ConcurrentHashMap.newKeySet();
+    private final KeyedRefCounter<ClosedChunkIndex> snapshottedIndexes = new KeyedRefCounter<>();
     private final Scheduler.Cancellable mgmtTaskScheduler;
     private final TimeUnit resolution;
     private final Settings indexSettings;
@@ -540,18 +540,21 @@ public class ClosedChunkIndexManager implements Closeable {
     private void deleteOrphanDirectories() throws IOException {
         log.debug("Starting cleanup of orphan directories");
         List<Path> currentPaths = new ArrayList<>();
+        // Normalize all paths for consistency.
         // prevent indexes pending removal from being deleted to allow proper closing sequence to be executed.
-        Set<Path> livePaths = pendingClosureIndexes.stream().map(ClosedChunkIndex::getPath).collect(Collectors.toSet());
+        Set<Path> livePaths = pendingClosureIndexes.stream()
+            .map(idx -> idx.getPath().toAbsolutePath().normalize())
+            .collect(Collectors.toSet());
 
         lock.lock();
         try (var paths = Files.newDirectoryStream(dir, BLOCK_PREFIX + "*")) {
             for (Path path : paths) {
-                currentPaths.add(path);
+                currentPaths.add(path.toAbsolutePath().normalize());
             }
             // read live indexes
-            closedChunkIndexMap.values().stream().map(ClosedChunkIndex::getPath).forEach(livePaths::add);
+            closedChunkIndexMap.values().stream().map(idx -> idx.getPath().toAbsolutePath().normalize()).forEach(livePaths::add);
             // protect snapshotted indexes from deletion
-            snapshottedIndexes.stream().map(ClosedChunkIndex::getPath).forEach(livePaths::add);
+            snapshottedIndexes.keys().stream().map(idx -> idx.getPath().toAbsolutePath().normalize()).forEach(livePaths::add);
         } finally {
             lock.unlock();
         }
@@ -559,7 +562,7 @@ public class ClosedChunkIndexManager implements Closeable {
         // delete paths
         for (Path path : currentPaths) {
             if (!livePaths.contains(path)) {
-                org.opensearch.tsdb.core.utils.Files.deleteDirectory(path.toAbsolutePath());
+                org.opensearch.tsdb.core.utils.Files.deleteDirectory(path);
                 log.info("Deleted orphan directory: {}", path);
             }
         }
@@ -825,14 +828,14 @@ public class ClosedChunkIndexManager implements Closeable {
                 try {
                     IndexCommit snapshot = index.snapshot();
                     snapshots.add(snapshot);
-                    snapshottedIndexes.add(index);
+                    snapshottedIndexes.acquire(index);
                     releaseActions.add(() -> {
                         try {
                             index.release(snapshot);
                         } catch (IOException e) {
                             log.warn("Failed to release closed chunk index snapshot", e);
                         }
-                        snapshottedIndexes.remove(index);
+                        snapshottedIndexes.release(index);
                     });
                 } catch (IOException | IllegalStateException e) {
                     log.warn("No index commit available for snapshot in closed chunk index", e);

--- a/src/main/java/org/opensearch/tsdb/core/index/live/LiveSeriesIndex.java
+++ b/src/main/java/org/opensearch/tsdb/core/index/live/LiveSeriesIndex.java
@@ -61,6 +61,7 @@ public class LiveSeriesIndex implements Closeable {
     protected static final String INDEX_DIR_NAME = "live_series_index";
     private final Analyzer analyzer;
     private final Directory directory;
+    // LiveSeriesIndex does not modify the indexWriter, and hence we don't need locking/synchronization for the indexWriter
     private final IndexWriter indexWriter;
     private final SnapshotDeletionPolicy snapshotDeletionPolicy;
     private final ReaderManager directoryReaderManager;
@@ -91,7 +92,7 @@ public class LiveSeriesIndex implements Closeable {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             indexWriter = new IndexWriter(directory, iwc);
-            this.metadataManager = new SeriesMetadataManager(directory, indexWriter, snapshotDeletionPolicy);
+            this.metadataManager = new SeriesMetadataManager(directory, () -> indexWriter, snapshotDeletionPolicy);
             directoryReaderManager = new ReaderManager(DirectoryReader.open(indexWriter, true, false));
         } catch (IOException e) {
             // close resources as LiveSeriesIndex initialization failed

--- a/src/main/java/org/opensearch/tsdb/core/index/metadata/SeriesMetadataManager.java
+++ b/src/main/java/org/opensearch/tsdb/core/index/metadata/SeriesMetadataManager.java
@@ -7,46 +7,58 @@
  */
 package org.opensearch.tsdb.core.index.metadata;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
+import org.opensearch.tsdb.core.utils.KeyedRefCounter;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 /**
  * Manages live series metadata files with snapshot protection and cleanup.
  * This class handles the lifecycle of metadata files including writing, snapshot tracking,
  * and cleanup of old files while protecting files referenced by active snapshots.
+ *
+ * <p> SeriesMetadataManager is used from the LiveSeriesIndex and ClosedChunkIndex, and also references their IndexWriters.
+ * The caller (LiveSeriesIndex or ClosedChunkIndex) must ensure correct lifecycle of the IndexWriter instances.
  */
 public class SeriesMetadataManager {
-
+    private static final Logger log = LogManager.getLogger(SeriesMetadataManager.class);
     private static final String SERIES_METADATA_FILE_KEY = "live_series_metadata_file";
     private final Directory directory;
-    private final IndexWriter indexWriter;
+    private final Supplier<IndexWriter> indexWriterSupplier;
     private final SnapshotDeletionPolicy snapshotDeletionPolicy;
-    private final Map<IndexCommit, MetadataAwareIndexCommit> activeSnapshots;
+    private final KeyedRefCounter<IndexCommit> activeSnapshots;
     private final ReentrantLock metadataLock;
 
     /**
      * Create a new SeriesMetadataManager.
      *
      * @param directory the Lucene directory where metadata files are stored
-     * @param indexWriter the IndexWriter for the index
+     * @param indexWriterSupplier supplier that returns the current IndexWriter; the supplier
+     *                            is called each time an operation needs the writer, so it
+     *                            always reflects the writer currently owned by the caller
      * @param snapshotDeletionPolicy the snapshot deletion policy
      */
-    public SeriesMetadataManager(Directory directory, IndexWriter indexWriter, SnapshotDeletionPolicy snapshotDeletionPolicy) {
+    public SeriesMetadataManager(
+        Directory directory,
+        Supplier<IndexWriter> indexWriterSupplier,
+        SnapshotDeletionPolicy snapshotDeletionPolicy
+    ) {
         this.directory = directory;
-        this.indexWriter = indexWriter;
+        this.indexWriterSupplier = indexWriterSupplier;
         this.snapshotDeletionPolicy = snapshotDeletionPolicy;
-        this.activeSnapshots = new ConcurrentHashMap<>();
+        this.activeSnapshots = new KeyedRefCounter<>();
         this.metadataLock = new ReentrantLock();
     }
 
@@ -78,8 +90,9 @@ public class SeriesMetadataManager {
             commitData.put(SERIES_METADATA_FILE_KEY, metadataFilename);
             commitData.putAll(additionalCommitData);
 
-            indexWriter.setLiveCommitData(commitData.entrySet(), true);
-            indexWriter.commit();
+            IndexWriter writer = indexWriterSupplier.get();
+            writer.setLiveCommitData(commitData.entrySet(), true);
+            writer.commit();
 
             cleanupOldMetadataFiles();
         } finally {
@@ -94,7 +107,7 @@ public class SeriesMetadataManager {
      * @throws IOException if reading fails
      */
     public void applyMetadata(java.util.function.BiConsumer<Long, Long> consumer) throws IOException {
-        Iterable<Map.Entry<String, String>> commitData = indexWriter.getLiveCommitData();
+        Iterable<Map.Entry<String, String>> commitData = indexWriterSupplier.get().getLiveCommitData();
         if (commitData == null) {
             return;
         }
@@ -122,7 +135,7 @@ public class SeriesMetadataManager {
         IndexCommit luceneCommit = snapshotDeletionPolicy.snapshot();
         String metadataFilename = extractMetadataFilename(luceneCommit);
         MetadataAwareIndexCommit wrappedCommit = new MetadataAwareIndexCommit(luceneCommit, metadataFilename);
-        activeSnapshots.put(luceneCommit, wrappedCommit);
+        activeSnapshots.acquire(luceneCommit);
         return wrappedCommit;
     }
 
@@ -134,9 +147,13 @@ public class SeriesMetadataManager {
      */
     public void release(IndexCommit snapshot) throws IOException {
         IndexCommit luceneCommit = extractLuceneCommit(snapshot);
-        activeSnapshots.remove(luceneCommit);
+        activeSnapshots.release(luceneCommit);
         snapshotDeletionPolicy.release(luceneCommit);
-        indexWriter.deleteUnusedFiles();
+        try {
+            indexWriterSupplier.get().deleteUnusedFiles();
+        } catch (AlreadyClosedException e) {
+            log.warn("IndexWriter already closed when attempting to delete unused files after snapshot release", e);
+        }
         cleanupOldMetadataFiles();
     }
 
@@ -174,7 +191,7 @@ public class SeriesMetadataManager {
         metadataLock.lock();
         try {
             // Get current metadata filename from commit data (source of truth)
-            Iterable<Map.Entry<String, String>> commitData = indexWriter.getLiveCommitData();
+            Iterable<Map.Entry<String, String>> commitData = indexWriterSupplier.get().getLiveCommitData();
             String currentMetadataFile = null;
             if (commitData != null) {
                 for (Map.Entry<String, String> entry : commitData) {
@@ -185,12 +202,14 @@ public class SeriesMetadataManager {
                 }
             }
 
-            // Collect protected files (from active snapshots)
-            Set<String> protectedFiles = activeSnapshots.values()
-                .stream()
-                .map(MetadataAwareIndexCommit::getMetadataFilename)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+            // Collect protected files (from active snapshots).
+            Set<String> protectedFiles = new HashSet<>();
+            for (IndexCommit commit : activeSnapshots.keys()) {
+                String filename = extractMetadataFilename(commit);
+                if (filename != null) {
+                    protectedFiles.add(filename);
+                }
+            }
 
             // Always protect current file if it exists
             if (currentMetadataFile != null) {

--- a/src/main/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReader.java
+++ b/src/main/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReader.java
@@ -22,7 +22,6 @@ import org.opensearch.tsdb.core.index.live.LiveSeriesIndexLeafReader;
 import org.opensearch.tsdb.core.index.live.MemChunkReader;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.LongSupplier;
@@ -335,12 +334,12 @@ public class TSDBDirectoryReader extends DirectoryReader {
 
     @Override
     protected DirectoryReader doOpenIfChanged(IndexCommit indexCommit) throws IOException {
-        throw new UnsupportedEncodingException("TSDBDirectoryReader does not support opening with IndexCommit");
+        throw new UnsupportedOperationException("TSDBDirectoryReader does not support opening with IndexCommit");
     }
 
     @Override
     protected DirectoryReader doOpenIfChanged(IndexWriter indexWriter, boolean b) throws IOException {
-        throw new UnsupportedEncodingException("TSDBDirectoryReader does not support opening with IndexWriter");
+        throw new UnsupportedOperationException("TSDBDirectoryReader does not support opening with IndexWriter");
     }
 
     @Override

--- a/src/main/java/org/opensearch/tsdb/core/utils/KeyedRefCounter.java
+++ b/src/main/java/org/opensearch/tsdb/core/utils/KeyedRefCounter.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.core.utils;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A thread-safe, per-key reference counter.
+ *
+ * <p>Tracks the number of active holders for each key. A key is considered tracked as long as its
+ * count is &ge; 1. The entry is removed automatically when the last holder releases.
+ *
+ * @param <K> the key type
+ */
+public class KeyedRefCounter<K> {
+
+    private final ConcurrentHashMap<K, Integer> refCounts = new ConcurrentHashMap<>();
+
+    /**
+     * Acquire a hold on {@code key}, incrementing its reference count by one.
+     * If the key was not previously held its count is initialised to 1.
+     *
+     * @param key the key to acquire
+     */
+    public void acquire(K key) {
+        refCounts.merge(key, 1, Integer::sum);
+    }
+
+    /**
+     * Release one hold on {@code key}, decrementing its reference count by one.
+     * When the count reaches zero the entry is removed and the key is no longer considered held.
+     *
+     * @param key the key to release
+     */
+    public void release(K key) {
+        refCounts.compute(key, (k, v) -> (v == null || v <= 1) ? null : v - 1);
+    }
+
+    /**
+     * Returns {@code true} if at least one holder has acquired {@code key} and not yet released it.
+     *
+     * @param key the key to check
+     * @return {@code true} if the key is currently tracked
+     */
+    public boolean contains(K key) {
+        return refCounts.containsKey(key);
+    }
+
+    /**
+     * Returns a live view of all keys that are currently tracked (reference count &ge; 1).
+     * The returned set reflects concurrent modifications made to this counter.
+     *
+     * @return the set of currently tracked keys
+     */
+    public Set<K> keys() {
+        return refCounts.keySet();
+    }
+}

--- a/src/test/java/org/opensearch/index/engine/TSDBEngineTests.java
+++ b/src/test/java/org/opensearch/index/engine/TSDBEngineTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.Term;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterApplierService;
+import org.opensearch.common.SuppressForbidden;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
@@ -52,13 +53,20 @@ import org.opensearch.telemetry.metrics.Counter;
 import org.opensearch.telemetry.metrics.Histogram;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.telemetry.metrics.tags.Tags;
+import org.apache.lucene.index.KeepOnlyLastCommitDeletionPolicy;
+import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.tsdb.core.head.Head;
+import org.opensearch.tsdb.core.index.live.LiveSeriesIndex;
+import org.opensearch.tsdb.core.index.metadata.SeriesMetadataManager;
+import org.opensearch.tsdb.core.utils.KeyedRefCounter;
 import org.opensearch.tsdb.core.utils.Time;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.time.Clock;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1798,6 +1806,48 @@ public class TSDBEngineTests extends EngineTestCase {
             metricsEngine = null;
             engineStore = null;
             TSDBMetrics.cleanup();
+        }
+    }
+
+    @SuppressForbidden(reason = "reflection is needed to test by injecting a failing SnapshotDeletionPolicy")
+    public void testAcquireSafeIndexCommitReleasesSnapshotsOnPartialFailure() throws Exception {
+        // Ensure the live index has at least one commit so snapshotWithReleaseAction() succeeds
+        publishSample(1, createSampleJson(series1, 1000L, 10.0));
+        metricsEngine.flush(false, true);
+
+        // Inject an uninitialized SnapshotDeletionPolicy — its snapshot() throws because
+        // onInit() was never called (lastCommit == null inside the policy).
+        Field sdpField = TSDBEngine.class.getDeclaredField("snapshotDeletionPolicy");
+        sdpField.setAccessible(true);
+        SnapshotDeletionPolicy originalPolicy = (SnapshotDeletionPolicy) sdpField.get(metricsEngine);
+        SnapshotDeletionPolicy uninitializedPolicy = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
+        sdpField.set(metricsEngine, uninitializedPolicy);
+
+        try {
+            // acquireSafeIndexCommit() must fail because snapshotDeletionPolicy.snapshot() throws.
+            // The catch block must then run release actions for the already-acquired live snapshot.
+            expectThrows(EngineException.class, () -> metricsEngine.acquireSafeIndexCommit());
+
+            // Navigate to SeriesMetadataManager.activeSnapshots to verify the live snapshot was released.
+            Field headField = TSDBEngine.class.getDeclaredField("head");
+            headField.setAccessible(true);
+            Head head = (Head) headField.get(metricsEngine);
+
+            Field metadataManagerField = LiveSeriesIndex.class.getDeclaredField("metadataManager");
+            metadataManagerField.setAccessible(true);
+            SeriesMetadataManager metadataManager = (SeriesMetadataManager) metadataManagerField.get(head.getLiveSeriesIndex());
+
+            Field activeSnapshotsField = SeriesMetadataManager.class.getDeclaredField("activeSnapshots");
+            activeSnapshotsField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            KeyedRefCounter<Object> activeSnapshots = (KeyedRefCounter<Object>) activeSnapshotsField.get(metadataManager);
+
+            assertTrue(
+                "Live index snapshot must be released after failed acquireSafeIndexCommit — catch block cleanup did not run",
+                activeSnapshots.keys().isEmpty()
+            );
+        } finally {
+            sdpField.set(metricsEngine, originalPolicy);
         }
     }
 }

--- a/src/test/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndexManagerTests.java
+++ b/src/test/java/org/opensearch/tsdb/core/index/closed/ClosedChunkIndexManagerTests.java
@@ -1030,4 +1030,67 @@ public class ClosedChunkIndexManagerTests extends OpenSearchTestCase {
 
         manager.close();
     }
+
+    public void testConcurrentSnapshotHoldersRefcountProtectsFromDeletion() throws IOException {
+        Path tempDir = createTempDir("testConcurrentSnapshotHolders");
+
+        // Retention that immediately expires the CCI (1 ms window, 0 ms frequency) so every
+        // runOptimization() call will attempt to remove and delete it.
+        Clock frozenClock = Clock.fixed(Instant.ofEpochMilli(100_000_000L), ZoneId.of("UTC"));
+        TimeBasedRetention retention = new TimeBasedRetention(1L, 0L, frozenClock);
+
+        ClosedChunkIndexManager manager = new ClosedChunkIndexManager(
+            tempDir,
+            new InMemoryMetadataStore(),
+            retention,
+            new NoopCompaction(),
+            threadPool,
+            new ShardId("index", "uuid", 0),
+            defaultSettings
+        );
+
+        Labels labels = ByteLabels.fromStrings("metric", "cpu");
+        MemSeries series = new MemSeries(0, labels, SeriesEventListener.NOOP);
+        manager.addMemChunk(series, TestUtils.getMemChunk(5, 0, 1500));
+        manager.commitChangedIndexes(List.of(series));
+        assertEquals("Should have 1 index before snapshots", 1, manager.getNumBlocks());
+
+        // Simulate two concurrent holders (example: a long-running snapshot and a peer recovery)
+        ClosedChunkIndexManager.SnapshotResult firstHolder = manager.snapshotAllIndexes();
+        ClosedChunkIndexManager.SnapshotResult secondHolder = manager.snapshotAllIndexes();
+        assertEquals("First holder should capture 1 CCI", 1, firstHolder.indexCommits().size());
+        assertEquals("Second holder should capture 1 CCI", 1, secondHolder.indexCommits().size());
+
+        // Record the CCI directory path for later existence checks.
+        Path cciDirectory = ((org.apache.lucene.store.FSDirectory) firstHolder.indexCommits().get(0).getDirectory()).getDirectory();
+        assertTrue("CCI directory should exist after snapshots taken", Files.exists(cciDirectory));
+
+        // Step 1: First optimization — retention removes CCI from the index map and tries to close
+        // it, but closeIndexes() skips it because both holders are still active.
+        manager.runOptimization();
+        assertEquals("CCI should be removed from the live index map by retention", 0, manager.getNumBlocks());
+        assertTrue("CCI directory must still exist: both holders are still active", Files.exists(cciDirectory));
+
+        // Step 2: Peer recovery (first holder) completes and releases.
+        for (Runnable releaseAction : firstHolder.releaseActions()) {
+            releaseAction.run();
+        }
+
+        // Step 3: The snapshot (second holder) is still active.
+        // With reference counting, the CCI remains in snapshottedIndexes and the directory must remain on disk.
+        manager.runOptimization();
+        assertTrue("CCI directory must still exist: second snapshot holder is still active", Files.exists(cciDirectory));
+
+        // Step 4: The snapshot (second holder) finishes uploading and releases.
+        for (Runnable releaseAction : secondHolder.releaseActions()) {
+            releaseAction.run();
+        }
+
+        // Step 5: Both holders have released, CCI is now fully unprotected.
+        // closeIndexes() and deleteOrphanDirectories() should clean it up.
+        manager.runOptimization();
+        assertFalse("CCI directory must be deleted after all snapshot holders have released", Files.exists(cciDirectory));
+
+        manager.close();
+    }
 }

--- a/src/test/java/org/opensearch/tsdb/core/index/metadata/SeriesMetadataManagerTests.java
+++ b/src/test/java/org/opensearch/tsdb/core/index/metadata/SeriesMetadataManagerTests.java
@@ -36,7 +36,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Commit with metadata
                 Map<Long, Long> metadata = new HashMap<>();
@@ -63,7 +63,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Write metadata
                 Map<Long, Long> originalMetadata = new HashMap<>();
@@ -90,7 +90,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Commit with metadata
                 Map<Long, Long> metadata = Map.of(1L, 100L);
@@ -132,7 +132,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Commit 1
                 manager.commitWithMetadata(Map.of(1L, 100L));
@@ -176,7 +176,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Commit 1 and snapshot
                 manager.commitWithMetadata(Map.of(1L, 100L));
@@ -220,7 +220,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Commit with empty metadata
                 manager.commitWithMetadata(new HashMap<>());
@@ -243,7 +243,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Write large metadata (10K series)
                 Map<Long, Long> metadata = new HashMap<>();
@@ -274,7 +274,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Try to read metadata from empty index (no commits yet)
                 Map<Long, Long> readMetadata = new HashMap<>();
@@ -299,7 +299,7 @@ public class SeriesMetadataManagerTests extends OpenSearchTestCase {
             iwc.setIndexDeletionPolicy(snapshotDeletionPolicy);
 
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
-                SeriesMetadataManager manager = new SeriesMetadataManager(dir, writer, snapshotDeletionPolicy);
+                SeriesMetadataManager manager = new SeriesMetadataManager(dir, () -> writer, snapshotDeletionPolicy);
 
                 // Commit 1 - creates series_metadata_1
                 manager.commitWithMetadata(Map.of(1L, 100L));

--- a/src/test/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderTests.java
+++ b/src/test/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderTests.java
@@ -54,7 +54,6 @@ import org.junit.Test;
 import org.opensearch.tsdb.core.mapping.Constants;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -861,7 +860,7 @@ public class TSDBDirectoryReaderTests extends OpenSearchTestCase {
         }
     }
 
-    @Test(expected = UnsupportedEncodingException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testDoOpenIfChangedWithIndexCommitThrowsException() throws IOException {
         tsdbDirectoryReader = new TSDBDirectoryReader(
             liveReader,
@@ -872,10 +871,10 @@ public class TSDBDirectoryReaderTests extends OpenSearchTestCase {
             mmappedChunksManager,
             1L
         );
-        tsdbDirectoryReader.doOpenIfChanged(null); // IndexCommit parameter
+        tsdbDirectoryReader.doOpenIfChanged((IndexCommit) null); // IndexCommit parameter
     }
 
-    @Test(expected = UnsupportedEncodingException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testDoOpenIfChangedWithIndexWriterThrowsException() throws IOException {
         tsdbDirectoryReader = new TSDBDirectoryReader(
             liveReader,

--- a/src/test/java/org/opensearch/tsdb/core/utils/KeyedRefCounterTests.java
+++ b/src/test/java/org/opensearch/tsdb/core/utils/KeyedRefCounterTests.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.core.utils;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class KeyedRefCounterTests extends OpenSearchTestCase {
+
+    public void testAcquire() {
+        KeyedRefCounter<String> counter = new KeyedRefCounter<>();
+        assertFalse(counter.contains("a"));
+        counter.acquire("a");
+        assertTrue(counter.contains("a"));
+    }
+
+    public void testReleaseAfterSingleAcquireRemovesKey() {
+        KeyedRefCounter<String> counter = new KeyedRefCounter<>();
+        counter.acquire("a");
+        counter.release("a");
+        assertFalse(counter.contains("a"));
+        assertTrue(counter.keys().isEmpty());
+    }
+
+    public void testMultipleAcquiresRequireMatchingReleases() {
+        KeyedRefCounter<String> counter = new KeyedRefCounter<>();
+        counter.acquire("a");
+        counter.acquire("a");
+        counter.release("a");
+        assertTrue("key must still be tracked after first release", counter.contains("a"));
+        counter.release("a");
+        assertFalse("key must be gone after last release", counter.contains("a"));
+    }
+
+    public void testReleaseOnUnknownKeyIsNoop() {
+        KeyedRefCounter<String> counter = new KeyedRefCounter<>();
+        counter.release("nonexistent"); // must not throw
+        assertFalse(counter.contains("nonexistent"));
+    }
+
+    public void testKeysReflectsAllAcquiredKeys() {
+        KeyedRefCounter<String> counter = new KeyedRefCounter<>();
+        counter.acquire("a");
+        counter.acquire("b");
+        assertTrue(counter.keys().contains("a"));
+        assertTrue(counter.keys().contains("b"));
+        assertEquals(2, counter.keys().size());
+        counter.release("a");
+        assertFalse(counter.keys().contains("a"));
+        assertTrue(counter.keys().contains("b"));
+    }
+}


### PR DESCRIPTION
### Description
This PR solves following two problems
1. Currently if a snapshot of an index commit is acquired by two separate flows (for example: index snapshotting and recovery), completion of any one releases the snapshot acquired by both, potentially resulting in snapshotting/recovery failures. This PR updates the index commit snapshot along with metadata file logic to use reference counting to avoid this problem.
2. Compaction currently closes the indexWriter and opens a new one. This switch is done in the CCI manager, but the metadata manager continues to refer to the older closed indexWriter, resulting in failed future indexWriter operations. This PR fixes this by synchronizing and managing the indexWriter lifecycle better. The failed indexWriter operation is mostly when compaction either doesn't complete successfully or in corner/race scenarios, so we also suppress AlreadyClosed exceptions.

Index SnapshotITs will be added separately, as it requires upgrading the OS core version to 3.6.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
