### PR TITLE
add coordinator profiling support

### DIFF
--- a/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
+++ b/src/main/java/org/opensearch/tsdb/TSDBPlugin.java
@@ -65,7 +65,9 @@ import org.opensearch.tsdb.query.fetch.LabelsFetchSubPhase;
 import org.opensearch.tsdb.query.search.CachedWildcardQueryBuilder;
 import org.opensearch.tsdb.query.search.TimeRangePruningQueryBuilder;
 import org.opensearch.tsdb.query.aggregator.InternalTimeSeries;
+import org.opensearch.tsdb.query.aggregator.InternalTimeSeriesWithCoordinatorProfile;
 import org.opensearch.tsdb.query.aggregator.InternalTSDBStats;
+import org.opensearch.tsdb.query.aggregator.ProfilingTimeSeriesCoordinatorAggregationBuilder;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesCoordinatorAggregationBuilder;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesInplaceAggregationBuilder;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesUnfoldAggregationBuilder;
@@ -107,6 +109,7 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
     // Search plugin constants
     private static final String TIME_SERIES_NAMED_WRITEABLE_NAME = "time_series";
     private static final String TSDB_STATS_NAMED_WRITEABLE_NAME = "tsdb_stats";
+    private static final String TSDB_COORDINATOR_PROFILE_WRITEABLE_NAME = "time_series_with_coordinator_profile";
 
     // Store plugin constants
     private static final String TSDB_STORE_FACTORY_NAME = "tsdb_store";
@@ -832,7 +835,13 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
                 TimeSeriesCoordinatorAggregationBuilder.NAME,
                 TimeSeriesCoordinatorAggregationBuilder::new,
                 TimeSeriesCoordinatorAggregationBuilder::parse
-            ).addResultReader(InternalTimeSeries::new)
+            ).addResultReader(InternalTimeSeries::new),
+            // Register ProfilingTimeSeriesCoordinatorAggregation
+            new PipelineAggregationSpec(
+                ProfilingTimeSeriesCoordinatorAggregationBuilder.NAME,
+                ProfilingTimeSeriesCoordinatorAggregationBuilder::new,
+                ProfilingTimeSeriesCoordinatorAggregationBuilder::parse
+            ).addResultReader(InternalTimeSeriesWithCoordinatorProfile::new)
         );
     }
 
@@ -914,7 +923,12 @@ public class TSDBPlugin extends Plugin implements SearchPlugin, EnginePlugin, Ac
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         return List.of(
             new NamedWriteableRegistry.Entry(InternalAggregation.class, TIME_SERIES_NAMED_WRITEABLE_NAME, InternalTimeSeries::new),
-            new NamedWriteableRegistry.Entry(InternalAggregation.class, TSDB_STATS_NAMED_WRITEABLE_NAME, InternalTSDBStats::new)
+            new NamedWriteableRegistry.Entry(InternalAggregation.class, TSDB_STATS_NAMED_WRITEABLE_NAME, InternalTSDBStats::new),
+            new NamedWriteableRegistry.Entry(
+                InternalAggregation.class,
+                TSDB_COORDINATOR_PROFILE_WRITEABLE_NAME,
+                InternalTimeSeriesWithCoordinatorProfile::new
+            )
         );
     }
 

--- a/src/main/java/org/opensearch/tsdb/lang/m3/dsl/SourceBuilderVisitor.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/dsl/SourceBuilderVisitor.java
@@ -141,6 +141,7 @@ import org.opensearch.tsdb.lang.m3.m3ql.plan.visitor.M3PlanVisitor;
 import org.opensearch.tsdb.lang.m3.stage.ValueFilterStage;
 import org.opensearch.tsdb.metrics.TSDBMetrics;
 import org.opensearch.tsdb.metrics.TSDBMetricsConstants;
+import org.opensearch.tsdb.query.aggregator.ProfilingTimeSeriesCoordinatorAggregationBuilder;
 import org.opensearch.tsdb.query.search.CachedWildcardQueryBuilder;
 import org.opensearch.tsdb.query.search.TimeRangePruningQueryBuilder;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesCoordinatorAggregationBuilder;
@@ -473,7 +474,8 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
 
             // Set the coordinator aggregation builder for the FetchPlanNode
             holder.addPipelineAggregationBuilder(
-                new TimeSeriesCoordinatorAggregationBuilder(
+                getCoordinatorBuilder(
+                    params,
                     planNode.getId() + COORDINATOR_NAME_SUFFIX,
                     stages,
                     EMPTY_MAP,
@@ -529,7 +531,8 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
         // Add coordinator that references the unfold aggregation
         String unfoldPath = planNode.getId() + ">" + unfoldAggName;
         holder.addPipelineAggregationBuilder(
-            new TimeSeriesCoordinatorAggregationBuilder(
+            getCoordinatorBuilder(
+                params,
                 planNode.getId() + COORDINATOR_NAME_SUFFIX,
                 coordinatorStages,
                 EMPTY_MAP,  // No macros
@@ -583,7 +586,8 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
         // Add coordinator that references the unfold aggregation
         String unfoldPath = planNode.getId() + ">" + unfoldAggName;
         holder.addPipelineAggregationBuilder(
-            new TimeSeriesCoordinatorAggregationBuilder(
+            getCoordinatorBuilder(
+                params,
                 planNode.getId() + COORDINATOR_NAME_SUFFIX,
                 coordinatorStages,
                 EMPTY_MAP,  // No macros
@@ -1077,7 +1081,7 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
             // Create child visitors with isRootVisitor=false since these are sub-plans
             childComponents[i] = new SourceBuilderVisitor(params, context).process(child);
         }
-        ComponentHolder merged = ComponentHolder.merge(planNode.getId(), childComponents);
+        ComponentHolder merged = ComponentHolder.merge(planNode.getId(), params, childComponents);
 
         // Add a UnionStage for each additional child beyond the first
         List<PipelineStage> stages = new ArrayList<>();
@@ -1110,7 +1114,7 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
         String lhsId = String.valueOf(lhsComponents.getId());
         referencesMap.put(lhsId, getTerminalReference(lhsComponents));
         merged.addPipelineAggregationBuilder(
-            new TimeSeriesCoordinatorAggregationBuilder(String.valueOf(planNode.getId()), stages, EMPTY_MAP, referencesMap, lhsId)
+            getCoordinatorBuilder(params, String.valueOf(planNode.getId()), stages, EMPTY_MAP, referencesMap, lhsId)
         );
 
         return merged;
@@ -1136,6 +1140,22 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
             return new UnionStage(rhsReferenceName);
         }
         throw new IllegalArgumentException("Unsupported plan node type for binary operation: " + planNode.getClass().getSimpleName());
+    }
+
+    private static TimeSeriesCoordinatorAggregationBuilder getCoordinatorBuilder(
+        M3OSTranslator.Params params,
+        String name,
+        List<PipelineStage> stages,
+        LinkedHashMap<String, TimeSeriesCoordinatorAggregator.MacroDefinition> macroDefinitions,
+        Map<String, String> references,
+        String inputReference
+    ) {
+        if (params.profile()) {
+            return new ProfilingTimeSeriesCoordinatorAggregationBuilder(name, stages, macroDefinitions, references, inputReference);
+        } else {
+            return new TimeSeriesCoordinatorAggregationBuilder(name, stages, macroDefinitions, references, inputReference);
+        }
+
     }
 
     /* package-private for test purpose */
@@ -1324,7 +1344,7 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
             return id;
         }
 
-        private static ComponentHolder merge(int id, ComponentHolder... holders) {
+        private static ComponentHolder merge(int id, M3OSTranslator.Params params, ComponentHolder... holders) {
             assert holders.length >= 2 : "should only merge multiple ComponentHolders";
 
             ComponentHolder merged = new ComponentHolder(id);
@@ -1364,7 +1384,8 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
                             )
                         );
 
-                    TimeSeriesCoordinatorAggregationBuilder lifted = new TimeSeriesCoordinatorAggregationBuilder(
+                    TimeSeriesCoordinatorAggregationBuilder lifted = getCoordinatorBuilder(
+                        params,
                         existing.getName(),
                         existing.getStages(),
                         EMPTY_MAP,

--- a/src/main/java/org/opensearch/tsdb/lang/m3/dsl/SourceBuilderVisitor.java
+++ b/src/main/java/org/opensearch/tsdb/lang/m3/dsl/SourceBuilderVisitor.java
@@ -456,6 +456,10 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
                     params.step()
                 );
 
+                if (params.profile()) {
+                    unfoldPipelineAggregationBuilder.setMetadata(Map.of("_enable_coordinator_profiling", true));
+                }
+
                 // Set the unfold aggregation builder for the FetchPlanNode
                 holder.setUnfoldAggregationBuilder(unfoldPipelineAggregationBuilder);
             }
@@ -522,6 +526,9 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
             params.endTime(),
             params.step()
         );
+        if (params.profile()) {
+            unfoldAgg.setMetadata(Map.of("_enable_coordinator_profiling", true));
+        }
 
         // Wrap unfold in a filter aggregation with MatchNoneQueryBuilder
         FilterAggregationBuilder filterAgg = new FilterAggregationBuilder(String.valueOf(planNode.getId()), new MatchNoneQueryBuilder());
@@ -577,6 +584,9 @@ public class SourceBuilderVisitor extends M3PlanVisitor<SourceBuilderVisitor.Com
             params.endTime(),
             params.step()
         );
+        if (params.profile()) {
+            unfoldAgg.setMetadata(Map.of("_enable_coordinator_profiling", true));
+        }
 
         // Wrap unfold in a filter aggregation with MatchNoneQueryBuilder
         FilterAggregationBuilder filterAgg = new FilterAggregationBuilder(String.valueOf(planNode.getId()), new MatchNoneQueryBuilder());

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/CoordinatorProfileInfo.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/CoordinatorProfileInfo.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.aggregator;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Holds profiling information for coordinator-level query execution.
+ * Includes stage-by-stage timing breakdown and total coordinator reduce time.
+ */
+public class CoordinatorProfileInfo implements Writeable, ToXContentFragment {
+    private final String stages;
+    private final long reduceTimeNanos;
+    private final long totalTimeNanos;
+
+    public CoordinatorProfileInfo(String stages, long reduceTimeNanos, long totalTimeNanos) {
+        this.stages = stages;
+        this.reduceTimeNanos = reduceTimeNanos;
+        this.totalTimeNanos = totalTimeNanos;
+    }
+
+    public CoordinatorProfileInfo(StreamInput in) throws IOException {
+        this.stages = in.readString();
+        this.reduceTimeNanos = in.readVLong();
+        this.totalTimeNanos = in.readVLong();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(stages);
+        out.writeVLong(reduceTimeNanos);
+        out.writeVLong(totalTimeNanos);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field("stages", stages);
+        builder.field("reduce_time_ns", reduceTimeNanos);
+        builder.field("total_profiled_stages_time_ns", totalTimeNanos);
+        return builder;
+    }
+
+    public String getStages() {
+        return stages;
+    }
+
+    public long getReduceTimeNanos() {
+        return reduceTimeNanos;
+    }
+
+    public long getTotalTimeNanos() {
+        return totalTimeNanos;
+    }
+}

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/CoordinatorProfileInfo.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/CoordinatorProfileInfo.java
@@ -17,23 +17,40 @@ import java.io.IOException;
 
 /**
  * Holds profiling information for coordinator-level query execution.
- * Includes stage-by-stage timing breakdown and total coordinator reduce time.
+ * Includes stage-by-stage timing breakdown and total coordinator reduce time,
+ * plus timing for the shard-level reduce, serialization, and deserialization phases.
  */
 public class CoordinatorProfileInfo implements Writeable, ToXContentFragment {
     private final String stages;
     private final long reduceTimeNanos;
     private final long totalTimeNanos;
+    private final long internalReduceTimeNanos;
+    private final long serializeTimeNanos;
+    private final long deserializeTimeNanos;
 
-    public CoordinatorProfileInfo(String stages, long reduceTimeNanos, long totalTimeNanos) {
+    public CoordinatorProfileInfo(
+        String stages,
+        long reduceTimeNanos,
+        long totalTimeNanos,
+        long internalReduceTimeNanos,
+        long serializeTimeNanos,
+        long deserializeTimeNanos
+    ) {
         this.stages = stages;
         this.reduceTimeNanos = reduceTimeNanos;
         this.totalTimeNanos = totalTimeNanos;
+        this.internalReduceTimeNanos = internalReduceTimeNanos;
+        this.serializeTimeNanos = serializeTimeNanos;
+        this.deserializeTimeNanos = deserializeTimeNanos;
     }
 
     public CoordinatorProfileInfo(StreamInput in) throws IOException {
         this.stages = in.readString();
         this.reduceTimeNanos = in.readVLong();
         this.totalTimeNanos = in.readVLong();
+        this.internalReduceTimeNanos = in.readVLong();
+        this.serializeTimeNanos = in.readVLong();
+        this.deserializeTimeNanos = in.readVLong();
     }
 
     @Override
@@ -41,6 +58,9 @@ public class CoordinatorProfileInfo implements Writeable, ToXContentFragment {
         out.writeString(stages);
         out.writeVLong(reduceTimeNanos);
         out.writeVLong(totalTimeNanos);
+        out.writeVLong(internalReduceTimeNanos);
+        out.writeVLong(serializeTimeNanos);
+        out.writeVLong(deserializeTimeNanos);
     }
 
     @Override
@@ -48,6 +68,9 @@ public class CoordinatorProfileInfo implements Writeable, ToXContentFragment {
         builder.field("stages", stages);
         builder.field("reduce_time_ns", reduceTimeNanos);
         builder.field("total_profiled_stages_time_ns", totalTimeNanos);
+        builder.field("internal_reduce_ns", internalReduceTimeNanos);
+        builder.field("serialize_ns", serializeTimeNanos);
+        builder.field("deserialize_ns", deserializeTimeNanos);
         return builder;
     }
 
@@ -61,5 +84,17 @@ public class CoordinatorProfileInfo implements Writeable, ToXContentFragment {
 
     public long getTotalTimeNanos() {
         return totalTimeNanos;
+    }
+
+    public long getInternalReduceTimeNanos() {
+        return internalReduceTimeNanos;
+    }
+
+    public long getSerializeTimeNanos() {
+        return serializeTimeNanos;
+    }
+
+    public long getDeserializeTimeNanos() {
+        return deserializeTimeNanos;
     }
 }

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesWithCoordinatorProfile.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesWithCoordinatorProfile.java
@@ -10,6 +10,8 @@ package org.opensearch.tsdb.query.aggregator;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.InternalAggregation.ReduceContext;
 import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
 
 import java.io.IOException;
@@ -26,6 +28,9 @@ import java.util.Map;
 public class InternalTimeSeriesWithCoordinatorProfile extends InternalTimeSeries {
     private final CoordinatorProfileInfo coordinatorProfileInfo;
 
+    private final long serializeTimeNanos;
+    private final long deserializeTimeNanos;
+
     public InternalTimeSeriesWithCoordinatorProfile(
         String name,
         List<TimeSeries> timeSeries,
@@ -33,19 +38,45 @@ public class InternalTimeSeriesWithCoordinatorProfile extends InternalTimeSeries
         UnaryPipelineStage reduceStage,
         CoordinatorProfileInfo coordinatorProfileInfo
     ) {
-        super(name, timeSeries, metadata, reduceStage);
+        super(name, timeSeries, metadata, reduceStage, AggregationExecStats.EMPTY, AggregationDataSource.EMPTY);
         this.coordinatorProfileInfo = coordinatorProfileInfo;
+        this.serializeTimeNanos = 0;
+        this.deserializeTimeNanos = 0;
+    }
+
+    public InternalTimeSeriesWithCoordinatorProfile(
+        String name,
+        List<TimeSeries> timeSeries,
+        Map<String, Object> metadata,
+        UnaryPipelineStage reduceStage,
+        AggregationExecStats execStats,
+        AggregationDataSource dataSource,
+        CoordinatorProfileInfo coordinatorProfileInfo
+    ) {
+        super(name, timeSeries, metadata, reduceStage, execStats, dataSource);
+        this.coordinatorProfileInfo = coordinatorProfileInfo;
+        this.serializeTimeNanos = 0;
+        this.deserializeTimeNanos = 0;
     }
 
     public InternalTimeSeriesWithCoordinatorProfile(StreamInput in) throws IOException {
+        this(in, System.nanoTime());
+    }
+
+    private InternalTimeSeriesWithCoordinatorProfile(StreamInput in, long deserStart) throws IOException {
         super(in);
+        this.serializeTimeNanos = in.readLong();
+        this.deserializeTimeNanos = System.nanoTime() - deserStart;
         boolean hasProfileInfo = in.readBoolean();
         this.coordinatorProfileInfo = hasProfileInfo ? new CoordinatorProfileInfo(in) : null;
     }
 
     @Override
     public void doWriteTo(StreamOutput out) throws IOException {
+        long serStart = System.nanoTime();
         super.doWriteTo(out);
+        long serTimeNanos = System.nanoTime() - serStart;
+        out.writeLong(serTimeNanos);
         out.writeBoolean(coordinatorProfileInfo != null);
         if (coordinatorProfileInfo != null) {
             coordinatorProfileInfo.writeTo(out);
@@ -63,12 +94,48 @@ public class InternalTimeSeriesWithCoordinatorProfile extends InternalTimeSeries
         return builder;
     }
 
-    public CoordinatorProfileInfo getCoordinatorProfileInfo() {
-        return coordinatorProfileInfo;
+    @Override
+    public InternalAggregation reduce(List<InternalAggregation> aggregations, ReduceContext reduceContext) {
+        if (!reduceContext.isFinalReduce()) {
+            return super.reduce(aggregations, reduceContext);
+        }
+
+        long reduceStart = System.nanoTime();
+        long totalSerNanos = 0;
+        long totalDeserNanos = 0;
+
+        for (InternalAggregation agg : aggregations) {
+            if (agg instanceof InternalTimeSeriesWithCoordinatorProfile p) {
+                totalSerNanos += p.getSerializeTimeNanos();
+                totalDeserNanos += p.getDeserializeTimeNanos();
+            }
+        }
+
+        InternalAggregation result = super.reduce(aggregations, reduceContext);
+        long internalReduceTimeNanos = System.nanoTime() - reduceStart;
+
+        List<TimeSeries> resultTs = ((InternalTimeSeries) result).getTimeSeries();
+        UnaryPipelineStage resultRs = ((InternalTimeSeries) result).getReduceStage();
+        AggregationExecStats resultExecStats = ((InternalTimeSeries) result).getExecStats();
+        AggregationDataSource resultDataSource = ((InternalTimeSeries) result).getDataSource();
+        CoordinatorProfileInfo info = new CoordinatorProfileInfo("", 0L, 0L, internalReduceTimeNanos, totalSerNanos, totalDeserNanos);
+        return new InternalTimeSeriesWithCoordinatorProfile(name, resultTs, metadata, resultRs, resultExecStats, resultDataSource, info);
     }
 
     @Override
     public String getWriteableName() {
         return "time_series_with_coordinator_profile";
+    }
+
+    public CoordinatorProfileInfo getCoordinatorProfileInfo() {
+        return coordinatorProfileInfo;
+    }
+
+    public long getSerializeTimeNanos() {
+        return serializeTimeNanos;
+    }
+
+    public long getDeserializeTimeNanos() {
+        return deserializeTimeNanos;
     }
 }

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesWithCoordinatorProfile.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesWithCoordinatorProfile.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.aggregator;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.tsdb.query.stage.UnaryPipelineStage;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extension of InternalTimeSeries that includes comprehensive coordinator-level profiling information.
+ *
+ * <p>This class wraps time series results along with detailed profiling metrics collected
+ * during coordinator-level aggregation processing, including stage timings, data volumes,
+ * and performance metrics.</p>
+ */
+public class InternalTimeSeriesWithCoordinatorProfile extends InternalTimeSeries {
+    private final CoordinatorProfileInfo coordinatorProfileInfo;
+
+    public InternalTimeSeriesWithCoordinatorProfile(
+        String name,
+        List<TimeSeries> timeSeries,
+        Map<String, Object> metadata,
+        UnaryPipelineStage reduceStage,
+        CoordinatorProfileInfo coordinatorProfileInfo
+    ) {
+        super(name, timeSeries, metadata, reduceStage);
+        this.coordinatorProfileInfo = coordinatorProfileInfo;
+    }
+
+    public InternalTimeSeriesWithCoordinatorProfile(StreamInput in) throws IOException {
+        super(in);
+        boolean hasProfileInfo = in.readBoolean();
+        this.coordinatorProfileInfo = hasProfileInfo ? new CoordinatorProfileInfo(in) : null;
+    }
+
+    @Override
+    public void doWriteTo(StreamOutput out) throws IOException {
+        super.doWriteTo(out);
+        out.writeBoolean(coordinatorProfileInfo != null);
+        if (coordinatorProfileInfo != null) {
+            coordinatorProfileInfo.writeTo(out);
+        }
+    }
+
+    @Override
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        super.doXContentBody(builder, params);
+        if (coordinatorProfileInfo != null) {
+            builder.startObject("coordinator_profile");
+            coordinatorProfileInfo.toXContent(builder, params);
+            builder.endObject();
+        }
+        return builder;
+    }
+
+    public CoordinatorProfileInfo getCoordinatorProfileInfo() {
+        return coordinatorProfileInfo;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return "time_series_with_coordinator_profile";
+    }
+}

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/ProfilingTimeSeriesCoordinatorAggregationBuilder.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/ProfilingTimeSeriesCoordinatorAggregationBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.aggregator;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
+import org.opensearch.tsdb.query.stage.PipelineStage;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Profiling-enabled coordinator aggregation builder.
+ *
+ * <p>This builder creates {@link TimeSeriesCoordinatorAggregator} instances with profiling enabled,
+ * which collects performance metrics for coordinator-level pipeline stages and returns results
+ * wrapped in {@link InternalTimeSeriesWithCoordinatorProfile}.</p>
+ *
+ * <p>This builder uses a separate {@link #NAME} to maintain backward compatibility during rolling
+ * upgrades. Old nodes will only deserialize the standard coordinator builder, while new nodes can
+ * deserialize both.</p>
+ *
+ * @see TimeSeriesCoordinatorAggregationBuilder
+ * @see InternalTimeSeriesWithCoordinatorProfile
+ */
+public class ProfilingTimeSeriesCoordinatorAggregationBuilder extends TimeSeriesCoordinatorAggregationBuilder {
+    public static final String NAME = "coordinator_pipeline_with_profile";
+
+    public ProfilingTimeSeriesCoordinatorAggregationBuilder(
+        String name,
+        List<PipelineStage> stages,
+        LinkedHashMap<String, TimeSeriesCoordinatorAggregator.MacroDefinition> macroDefinitions,
+        Map<String, String> references,
+        String inputReference
+    ) {
+        super(name, stages, macroDefinitions, references, inputReference);
+    }
+
+    public ProfilingTimeSeriesCoordinatorAggregationBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    protected PipelineAggregator createInternal(Map<String, Object> metadata) {
+        Map<String, Object> metadataWithProfile = metadata != null ? new HashMap<>(metadata) : new HashMap<>();
+        metadataWithProfile.put("_enable_coordinator_profiling", true);
+
+        return new TimeSeriesCoordinatorAggregator(
+            name,
+            bucketsPaths,
+            getStages(),
+            getMacroDefinitions(),
+            getReferences(),
+            getInputReference(),
+            metadataWithProfile
+        );
+    }
+
+    @Override
+    public String getType() {
+        return NAME;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    public static ProfilingTimeSeriesCoordinatorAggregationBuilder parse(String aggregationName, XContentParser parser) throws IOException {
+        TimeSeriesCoordinatorAggregationBuilder base = TimeSeriesCoordinatorAggregationBuilder.parse(aggregationName, parser);
+
+        return new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            base.getName(),
+            base.getStages(),
+            base.getMacroDefinitions(),
+            base.getReferences(),
+            base.getInputReference()
+        );
+    }
+}

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregationBuilder.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregationBuilder.java
@@ -267,9 +267,21 @@ public class TimeSeriesCoordinatorAggregationBuilder extends AbstractPipelineAgg
 
     @Override
     protected PipelineAggregator createInternal(Map<String, Object> metadata) {
+        Map<String, Object> metadataWithProfile = metadata != null ? new HashMap<>(metadata) : new HashMap<>();
+        if (metadata != null && metadata.containsKey("profile") && (Boolean) metadata.get("profile")) {
+            metadataWithProfile.put("_profiling_enabled", true);
+        }
         // Validate before creating the aggregator
         validateAndThrow();
-        return new TimeSeriesCoordinatorAggregator(name, bucketsPaths, stages, macroDefinitions, references, inputReference, metadata);
+        return new TimeSeriesCoordinatorAggregator(
+            name,
+            bucketsPaths,
+            stages,
+            macroDefinitions,
+            references,
+            inputReference,
+            metadataWithProfile
+        );
     }
 
     @Override

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregator.java
@@ -308,16 +308,50 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
             if (stageProfiler != null) {
                 long reduceTimeNanos = System.nanoTime() - reduceStartTime;
                 long totalTimeNanos = stageProfiler.getTotalTime();
+                long[] internalTimings = collectInternalTimings(aggregations);
                 CoordinatorProfileInfo profileInfo = new CoordinatorProfileInfo(
-                        stageProfiler.getResults(),
-                        reduceTimeNanos,
-                        totalTimeNanos
+                    stageProfiler.getResults(),
+                    reduceTimeNanos,
+                    totalTimeNanos,
+                    internalTimings[0],  // internalReduceTimeNanos
+                    internalTimings[1],  // serializeTimeNanos
+                    internalTimings[2]   // deserializeTimeNanos
                 );
                 return new InternalTimeSeriesWithCoordinatorProfile(name(), result, metadata(), null, profileInfo);
             }
 
             return new InternalTimeSeries(name(), result, metadata(), null, mergedStats, mergedDataSource);
         }
+    }
+
+    /**
+     * Traverse the already-reduced reference aggregations and collect the internal timing
+     * values embedded by {@code InternalTimeSeries.reduce()} when profiling is enabled.
+     *
+     * @return {@code long[3]} – {@code [internalReduceNanos, serializeNanos, deserializeNanos]}
+     */
+    private long[] collectInternalTimings(Aggregations aggregations) {
+        long internalReduceTotal = 0;
+        long serTotal = 0;
+        long deserTotal = 0;
+        for (String bucketsPath : references.values()) {
+            String[] pathElements = bucketsPath.split(AggregationConstants.BUCKETS_PATH_SEPARATOR);
+            Aggregation agg = aggregations.get(pathElements[0]);
+            for (int i = 1; i < pathElements.length && agg != null; i++) {
+                if (agg instanceof InternalSingleBucketAggregation single) {
+                    agg = single.getAggregations().get(pathElements[i]);
+                } else {
+                    agg = null;
+                }
+            }
+            if (agg instanceof InternalTimeSeriesWithCoordinatorProfile p && p.getCoordinatorProfileInfo() != null) {
+                CoordinatorProfileInfo partial = p.getCoordinatorProfileInfo();
+                internalReduceTotal += partial.getInternalReduceTimeNanos();
+                serTotal += partial.getSerializeTimeNanos();
+                deserTotal += partial.getDeserializeTimeNanos();
+            }
+        }
+        return new long[] { internalReduceTotal, serTotal, deserTotal };
     }
 
     /**

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregator.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.function.LongConsumer;
 
 import org.opensearch.tsdb.query.breaker.ReduceCircuitBreakerConsumer;
+import org.opensearch.tsdb.query.utils.StageProfiler;
 
 /**
  * Coordinator pipeline aggregator that handles a list of pipeline stages at the coordinator.
@@ -270,9 +271,19 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
      */
     @Override
     public InternalAggregation doReduce(Aggregations aggregations, ReduceContext context) {
+        // Conditionally enable profiling
+        StageProfiler stageProfiler = null;
+        boolean profilingEnabled = isProfilingEnabled();
+
+        if (context.isFinalReduce() && profilingEnabled) {
+            stageProfiler = new StageProfiler();
+        }
+
         try (ReduceCircuitBreakerConsumer cbConsumer = ReduceCircuitBreakerConsumer.createConsumer(context)) {
-            // Execute the main pipeline stages, with macro support if macros are defined
-            List<TimeSeries> result = processMainPipeline(aggregations, cbConsumer);
+            long reduceStartTime = System.nanoTime();
+
+            // Execute the main pipeline stages with optional profiling
+            List<TimeSeries> result = processMainPipeline(aggregations, cbConsumer, stageProfiler);
 
             // Track final result size for OOM protection (list + all time series)
             if (result != null && !result.isEmpty()) {
@@ -293,6 +304,18 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
                 }
             }
 
+            // Return profiled version if profiling was enabled
+            if (stageProfiler != null) {
+                long reduceTimeNanos = System.nanoTime() - reduceStartTime;
+                long totalTimeNanos = stageProfiler.getTotalTime();
+                CoordinatorProfileInfo profileInfo = new CoordinatorProfileInfo(
+                        stageProfiler.getResults(),
+                        reduceTimeNanos,
+                        totalTimeNanos
+                );
+                return new InternalTimeSeriesWithCoordinatorProfile(name(), result, metadata(), null, profileInfo);
+            }
+
             return new InternalTimeSeries(name(), result, metadata(), null, mergedStats, mergedDataSource);
         }
     }
@@ -301,16 +324,30 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
      * Process the main pipeline stages, with support for macro references.
      * Macros are definitions that can be referenced by stages in the main pipeline.
      *
+     * Backwards-compatible overload that delegates to version with profiler support.
+     *
      * @param aggregations the aggregations to process
      * @param cbConsumer optional circuit breaker consumer for memory tracking
      */
     private List<TimeSeries> processMainPipeline(Aggregations aggregations, LongConsumer cbConsumer) {
+        return processMainPipeline(aggregations, cbConsumer, null);
+    }
+
+    /**
+     * Process the main pipeline stages with optional profiling support.
+     * Macros are definitions that can be referenced by stages in the main pipeline.
+     *
+     * @param aggregations the aggregations to process
+     * @param cbConsumer optional circuit breaker consumer for memory tracking
+     * @param stageProfiler optional profiler for measuring stage execution (null = no profiling)
+     */
+    private List<TimeSeries> processMainPipeline(Aggregations aggregations, LongConsumer cbConsumer, StageProfiler stageProfiler) {
         // Extract referenced pipeline results using buckets_path
         Map<String, List<TimeSeries>> availableReferences = extractReferenceResults(aggregations);
 
         // If we have macro definitions, evaluate them and append results to available references
         if (!macroDefinitions.isEmpty()) {
-            evaluateAndAppendMacros(availableReferences, cbConsumer);
+            evaluateAndAppendMacros(availableReferences, cbConsumer, stageProfiler);
         }
 
         // Execute the main pipeline stages
@@ -328,10 +365,10 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
             resultTimeSeries = availableReferences.get(inputReference);
         }
 
-        // Apply main pipeline stages sequentially with circuit breaker tracking
+        // Apply main pipeline stages sequentially with circuit breaker tracking and optional profiling
         // When availableReferences is empty (e.g., MockFetch), resultTimeSeries starts as null
         // and the first stage (MockFetchStage) generates data from scratch
-        resultTimeSeries = executeStages(stages, resultTimeSeries, availableReferences, cbConsumer);
+        resultTimeSeries = executeStages(stages, resultTimeSeries, availableReferences, cbConsumer, stageProfiler);
         return resultTimeSeries != null ? resultTimeSeries : List.of();
     }
 
@@ -340,16 +377,35 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
      * Macros can reference other macros, so they are evaluated in dependency order.
      * Modifies the availableReferences map in place.
      *
+     * Backwards-compatible overload that delegates to version with profiler support.
+     *
      * @param availableReferences the map of available references
      * @param cbConsumer optional circuit breaker consumer for memory tracking
      */
     private void evaluateAndAppendMacros(Map<String, List<TimeSeries>> availableReferences, LongConsumer cbConsumer) {
+        evaluateAndAppendMacros(availableReferences, cbConsumer, null);
+    }
+
+    /**
+     * Evaluate macro definitions with optional profiling support.
+     * Macros can reference other macros, so they are evaluated in dependency order.
+     * Modifies the availableReferences map in place.
+     *
+     * @param availableReferences the map of available references
+     * @param cbConsumer optional circuit breaker consumer for memory tracking
+     * @param stageProfiler optional profiler for measuring stage execution (null = no profiling)
+     */
+    private void evaluateAndAppendMacros(
+        Map<String, List<TimeSeries>> availableReferences,
+        LongConsumer cbConsumer,
+        StageProfiler stageProfiler
+    ) {
         // Evaluate macros in definition order as provided by the parser/planner
         // TODO: Support topological sort for automatic dependency resolution in the future
         for (MacroDefinition macro : macroDefinitions.values()) {
             // Execute the macro stages using all references available so far
             List<TimeSeries> macroInput = getMacroInput(availableReferences, macro);
-            List<TimeSeries> macroOutput = executeStages(macro.getStages(), macroInput, availableReferences, cbConsumer);
+            List<TimeSeries> macroOutput = executeStages(macro.getStages(), macroInput, availableReferences, cbConsumer, stageProfiler);
 
             // Add the macro output to available references for subsequent macros
             availableReferences.put(macro.getName(), macroOutput);
@@ -450,6 +506,8 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
     /**
      * Execute pipeline stages on time series data with circuit breaker tracking.
      *
+     * Backwards-compatible overload that delegates to version with profiler support.
+     *
      * @param stages the pipeline stages to execute
      * @param input the input time series
      * @param availableReferences the map of available references
@@ -460,6 +518,25 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
         List<TimeSeries> input,
         Map<String, List<TimeSeries>> availableReferences,
         LongConsumer cbConsumer
+    ) {
+        return executeStages(stages, input, availableReferences, cbConsumer, null);
+    }
+
+    /**
+     * Execute pipeline stages with optional profiling support.
+     *
+     * @param stages the pipeline stages to execute
+     * @param input the input time series
+     * @param availableReferences the map of available references
+     * @param cbConsumer optional circuit breaker consumer for memory tracking
+     * @param stageProfiler optional profiler for measuring stage execution (null = no profiling)
+     */
+    private List<TimeSeries> executeStages(
+        List<PipelineStage> stages,
+        List<TimeSeries> input,
+        Map<String, List<TimeSeries>> availableReferences,
+        LongConsumer cbConsumer,
+        StageProfiler stageProfiler
     ) {
         List<TimeSeries> resultTimeSeries = input;
 
@@ -478,6 +555,7 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
                     );
                 }
 
+                // Binary stages: profiling not yet supported
                 resultTimeSeries = PipelineStageExecutor.executeBinaryStage(
                     binaryStage,
                     left,
@@ -488,16 +566,30 @@ public class TimeSeriesCoordinatorAggregator extends SiblingPipelineAggregator {
             } else {
                 // Must be UnaryPipelineStage - all stages are validated in constructor
                 UnaryPipelineStage unaryStage = (UnaryPipelineStage) stage;
+
+                // Pass profiler to executor (null when profiling disabled = zero overhead)
                 resultTimeSeries = PipelineStageExecutor.executeUnaryStage(
                     unaryStage,
                     resultTimeSeries,
                     true, // coordinator-level execution
-                    cbConsumer
+                    cbConsumer,
+                    stageProfiler  // Profile data collected here when non-null
                 );
             }
         }
 
         return resultTimeSeries != null ? resultTimeSeries : List.of();
+    }
+
+    /**
+     * Check if coordinator profiling is enabled for this aggregation.
+     * Profiling is controlled via metadata flag set by the aggregation builder.
+     *
+     * @return true if profiling should be enabled, false otherwise
+     */
+    private boolean isProfilingEnabled() {
+        Object profilingFlag = metadata().get("_enable_coordinator_profiling");
+        return profilingFlag instanceof Boolean && (Boolean) profilingFlag;
     }
 
 }

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TimeSeriesUnfoldAggregator.java
@@ -464,9 +464,28 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
         }
     }
 
+    private boolean isProfilingEnabled() {
+        Map<String, Object> meta = metadata();
+        if (meta == null) return false;
+        Object flag = meta.get("_enable_coordinator_profiling");
+        return flag instanceof Boolean && (Boolean) flag;
+    }
+
     @Override
     public InternalAggregation buildEmptyAggregation() {
         Map<String, Object> emptyMetadata = metadata();
+        Map<String, Object> meta = emptyMetadata != null ? emptyMetadata : Map.of();
+        if (isProfilingEnabled()) {
+            return new InternalTimeSeriesWithCoordinatorProfile(
+                name,
+                List.of(),
+                meta,
+                null,
+                AggregationExecStats.EMPTY,
+                AggregationDataSource.EMPTY,
+                null
+            );
+        }
         return new InternalTimeSeries(
             name,
             List.of(),
@@ -517,14 +536,27 @@ public class TimeSeriesUnfoldAggregator extends BucketsAggregator {
 
                 // Use the generic InternalPipeline with the reduce stage
                 Map<String, Object> baseMetadata = metadata();
-                results[i] = new InternalTimeSeries(
-                    name,
-                    timeSeriesList,
-                    baseMetadata != null ? baseMetadata : Map.of(),
-                    reduceStage,  // Pass the reduce stage (null for transformation stages)
-                    execStats,
-                    dataSource
-                );
+                Map<String, Object> meta = baseMetadata != null ? baseMetadata : Map.of();
+                if (isProfilingEnabled()) {
+                    results[i] = new InternalTimeSeriesWithCoordinatorProfile(
+                        name,
+                        timeSeriesList,
+                        meta,
+                        reduceStage,
+                        execStats,
+                        dataSource,
+                        null
+                    );
+                } else {
+                    results[i] = new InternalTimeSeries(
+                        name,
+                        timeSeriesList,
+                        baseMetadata != null ? baseMetadata : Map.of(),
+                        reduceStage,  // Pass the reduce stage (null for transformation stages)
+                        execStats,
+                        dataSource
+                    );
+                }
             }
             return results;
         } finally {

--- a/src/main/java/org/opensearch/tsdb/query/utils/ProfileInfoMapper.java
+++ b/src/main/java/org/opensearch/tsdb/query/utils/ProfileInfoMapper.java
@@ -9,7 +9,10 @@ package org.opensearch.tsdb.query.utils;
 
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.aggregations.Aggregation;
+import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.profile.ProfileShardResult;
+import org.opensearch.tsdb.query.aggregator.InternalTimeSeriesWithCoordinatorProfile;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,6 +25,7 @@ public class ProfileInfoMapper {
     // Field names for profile output structure
     private static final String PROFILE_FIELD_NAME = "profile";
     private static final String SHARDS_FIELD_NAME = "shards";
+    private static final String COORDINATOR_FIELD_NAME = "coordinator";
     private static final String SHARD_ID_FIELD_NAME = "id";
     private static final String AGGREGATION_FIELD_NAME = "aggregations";
     private static final String SEARCH_FIELD_NAME = "searches";
@@ -57,6 +61,7 @@ public class ProfileInfoMapper {
      *   <li>aggregations: Aggregation profiling results with breakdown times and debug info</li>
      *   <li>fetch: Fetch phase profiling</li>
      *   <li>network timing: Inbound/outbound network times in milliseconds</li>
+     *   <li>coordinator: Coordinator-level profiling information (if available)</li>
      * </ul>
      *
      * @param response the SearchResponse containing profile results
@@ -107,7 +112,42 @@ public class ProfileInfoMapper {
             }
 
             builder.endArray();
+
+            // Extract and add coordinator profiling information if available
+            extractCoordinatorProfileInfo(response, builder);
+
             builder.endObject();
+        }
+    }
+
+    /**
+     * Extracts coordinator-level profiling information from aggregation results.
+     *
+     * <p>This method checks if the top-level aggregations contain an {@link InternalTimeSeriesWithCoordinatorProfile}
+     * instance and extracts its profiling data to add as a "coordinator" field in the profile output.</p>
+     *
+     * @param response the SearchResponse containing aggregations
+     * @param builder the XContentBuilder to write the coordinator profiling data to
+     * @throws IOException if an I/O error occurs during writing
+     */
+    private static void extractCoordinatorProfileInfo(SearchResponse response, XContentBuilder builder) throws IOException {
+        Aggregations aggregations = response.getAggregations();
+        if (aggregations == null) {
+            return;
+        }
+
+        // Check each aggregation to see if it's an InternalTimeSeriesWithCoordinatorProfile
+        for (Aggregation agg : aggregations) {
+            if (agg instanceof InternalTimeSeriesWithCoordinatorProfile coordinatorProfileAgg) {
+                var coordinatorProfileInfo = coordinatorProfileAgg.getCoordinatorProfileInfo();
+                if (coordinatorProfileInfo != null) {
+                    builder.startObject(COORDINATOR_FIELD_NAME);
+                    coordinatorProfileInfo.toXContent(builder, EMPTY_PARAMS);
+                    builder.endObject();
+                    // Only add the first coordinator profile found
+                    break;
+                }
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/tsdb/query/utils/StageProfiler.java
+++ b/src/main/java/org/opensearch/tsdb/query/utils/StageProfiler.java
@@ -16,6 +16,7 @@ import java.util.List;
 public class StageProfiler {
 
     private final List<String> profileResults = new ArrayList<>();
+    private long totalTimeNanos = 0;
 
     /**
      * Record the stats of one stage
@@ -27,6 +28,7 @@ public class StageProfiler {
     public void record(String stageName, long latencyNs, long inputSampleCount, long memoryOverhead) {
         String result = stageName + "(" + inputSampleCount + "): " + latencyNs + " ns, " + memoryOverhead + " bytes";
         profileResults.add(result);
+        totalTimeNanos += latencyNs;
     }
 
     /**
@@ -35,5 +37,13 @@ public class StageProfiler {
      */
     public String getResults() {
         return String.join(";", profileResults);
+    }
+
+    /**
+     * Get the total time across all stages
+     * @return sum of all stage latencies in nanoseconds
+     */
+    public long getTotalTime() {
+        return totalTimeNanos;
     }
 }

--- a/src/test/java/org/opensearch/tsdb/TSDBPluginTests.java
+++ b/src/test/java/org/opensearch/tsdb/TSDBPluginTests.java
@@ -40,6 +40,7 @@ import org.opensearch.test.DummyShardLock;
 import org.opensearch.tsdb.query.fetch.LabelsFetchSubPhase;
 import org.opensearch.test.IndexSettingsModule;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.tsdb.query.aggregator.ProfilingTimeSeriesCoordinatorAggregationBuilder;
 import org.opensearch.tsdb.query.aggregator.TSDBStatsAggregationBuilder;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesCoordinatorAggregationBuilder;
 import org.opensearch.tsdb.query.aggregator.TimeSeriesInplaceAggregationBuilder;
@@ -368,13 +369,20 @@ public class TSDBPluginTests extends OpenSearchTestCase {
         List<SearchPlugin.PipelineAggregationSpec> pipelineAggregations = plugin.getPipelineAggregations();
 
         assertNotNull("Pipeline aggregations list should not be null", pipelineAggregations);
-        assertThat("Should have 1 pipeline aggregation", pipelineAggregations, hasSize(1));
+        assertThat("Should have 2 pipeline aggregations", pipelineAggregations, hasSize(2));
 
         SearchPlugin.PipelineAggregationSpec spec = pipelineAggregations.get(0);
         assertThat(
             "Pipeline aggregation name should match",
             spec.getName().getPreferredName(),
             equalTo(TimeSeriesCoordinatorAggregationBuilder.NAME)
+        );
+
+        SearchPlugin.PipelineAggregationSpec spec2 = pipelineAggregations.get(1);
+        assertThat(
+            "Second pipeline aggregation name should match",
+            spec2.getName().getPreferredName(),
+            equalTo(ProfilingTimeSeriesCoordinatorAggregationBuilder.NAME)
         );
     }
 
@@ -476,7 +484,7 @@ public class TSDBPluginTests extends OpenSearchTestCase {
         List<NamedWriteableRegistry.Entry> namedWriteables = plugin.getNamedWriteables();
 
         assertNotNull("Named writeables list should not be null", namedWriteables);
-        assertThat("Should have 2 named writeables", namedWriteables, hasSize(2));
+        assertThat("Should have 3 named writeables", namedWriteables, hasSize(3));
     }
 
     public void testInternalTimeSeriesNamedWriteable() {

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/CoordinatorProfileInfoTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/CoordinatorProfileInfoTests.java
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.aggregator;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+/**
+ * Unit tests for {@link CoordinatorProfileInfo}.
+ */
+public class CoordinatorProfileInfoTests extends OpenSearchTestCase {
+
+    // ========== Constructor Tests ==========
+
+    public void testConstructorBasic() {
+
+        String stages = "mockFetch(0): 1000000 ns, 100 bytes;scale(2): 500000 ns, 50 bytes";
+        long reduceTimeNanos = 2500000L;
+        long totalTimeNanos = 1500000L;
+        long internalReduceNanos = 300000L;
+        long serializeNanos = 400000L;
+        long deserializeNanos = 200000L;
+
+        CoordinatorProfileInfo profile = new CoordinatorProfileInfo(
+            stages,
+            reduceTimeNanos,
+            totalTimeNanos,
+            internalReduceNanos,
+            serializeNanos,
+            deserializeNanos
+        );
+
+        assertEquals(stages, profile.getStages());
+        assertEquals(reduceTimeNanos, profile.getReduceTimeNanos());
+        assertEquals(totalTimeNanos, profile.getTotalTimeNanos());
+        assertEquals(internalReduceNanos, profile.getInternalReduceTimeNanos());
+        assertEquals(serializeNanos, profile.getSerializeTimeNanos());
+        assertEquals(deserializeNanos, profile.getDeserializeTimeNanos());
+    }
+
+    public void testConstructorWithEmptyStages() {
+
+        CoordinatorProfileInfo profile = new CoordinatorProfileInfo("", 0L, 0L, 0L, 0L, 0L);
+
+        assertEquals("", profile.getStages());
+        assertEquals(0L, profile.getReduceTimeNanos());
+        assertEquals(0L, profile.getTotalTimeNanos());
+    }
+
+    public void testConstructorWithLargeValues() {
+
+        String stages = "very_long_stage_description_with_lots_of_details";
+        long largeValue1 = Long.MAX_VALUE / 2;
+        long largeValue2 = Long.MAX_VALUE / 3;
+
+        CoordinatorProfileInfo profile = new CoordinatorProfileInfo(
+            stages,
+            largeValue1,
+            largeValue2,
+            Long.MAX_VALUE / 4,
+            Long.MAX_VALUE / 5,
+            Long.MAX_VALUE / 6
+        );
+
+        assertEquals(stages, profile.getStages());
+        assertEquals(largeValue1, profile.getReduceTimeNanos());
+        assertEquals(largeValue2, profile.getTotalTimeNanos());
+    }
+
+    // ========== Serialization Tests ==========
+
+    public void testSerializationBasic() throws IOException {
+
+        CoordinatorProfileInfo original = new CoordinatorProfileInfo("test_stages", 123456L, 789012L, 345678L, 901234L, 567890L);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        CoordinatorProfileInfo deserialized = new CoordinatorProfileInfo(in);
+
+        assertEquals(original.getStages(), deserialized.getStages());
+        assertEquals(original.getReduceTimeNanos(), deserialized.getReduceTimeNanos());
+        assertEquals(original.getTotalTimeNanos(), deserialized.getTotalTimeNanos());
+        assertEquals(original.getInternalReduceTimeNanos(), deserialized.getInternalReduceTimeNanos());
+        assertEquals(original.getSerializeTimeNanos(), deserialized.getSerializeTimeNanos());
+        assertEquals(original.getDeserializeTimeNanos(), deserialized.getDeserializeTimeNanos());
+    }
+
+    public void testSerializationRoundTrip() throws IOException {
+
+        for (int i = 0; i < 10; i++) {
+            CoordinatorProfileInfo original = new CoordinatorProfileInfo(
+                "stage_" + i,
+                i * 1000L,
+                i * 2000L,
+                i * 3000L,
+                i * 4000L,
+                i * 5000L
+            );
+
+            BytesStreamOutput out = new BytesStreamOutput();
+            original.writeTo(out);
+
+            StreamInput in = out.bytes().streamInput();
+            CoordinatorProfileInfo deserialized = new CoordinatorProfileInfo(in);
+
+            assertEquals(original.getStages(), deserialized.getStages());
+            assertEquals(original.getReduceTimeNanos(), deserialized.getReduceTimeNanos());
+            assertEquals(original.getTotalTimeNanos(), deserialized.getTotalTimeNanos());
+            assertEquals(original.getInternalReduceTimeNanos(), deserialized.getInternalReduceTimeNanos());
+            assertEquals(original.getSerializeTimeNanos(), deserialized.getSerializeTimeNanos());
+            assertEquals(original.getDeserializeTimeNanos(), deserialized.getDeserializeTimeNanos());
+        }
+    }
+
+    // ========== XContent Tests ==========
+
+    public void testToXContentBasic() throws IOException {
+
+        CoordinatorProfileInfo profile = new CoordinatorProfileInfo("mockFetch: 1000 ns", 2000000L, 1500000L, 500000L, 300000L, 200000L);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        profile.toXContent(builder, null);
+        builder.endObject();
+
+        String json = builder.toString();
+        assertNotNull(json);
+        assertTrue(json.contains("\"stages\":\"mockFetch: 1000 ns\""));
+        assertTrue(json.contains("\"reduce_time_ns\":2000000"));
+        assertTrue(json.contains("\"total_profiled_stages_time_ns\":1500000"));
+        assertTrue(json.contains("\"internal_reduce_ns\":500000"));
+        assertTrue(json.contains("\"serialize_ns\":300000"));
+        assertTrue(json.contains("\"deserialize_ns\":200000"));
+    }
+
+    public void testToXContentWithZeroValues() throws IOException {
+
+        CoordinatorProfileInfo profile = new CoordinatorProfileInfo("", 0L, 0L, 0L, 0L, 0L);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        profile.toXContent(builder, null);
+        builder.endObject();
+
+        String json = builder.toString();
+        assertNotNull(json);
+        assertTrue(json.contains("\"stages\":\"\""));
+        assertTrue(json.contains("\"reduce_time_ns\":0"));
+        assertTrue(json.contains("\"total_profiled_stages_time_ns\":0"));
+        assertTrue(json.contains("\"internal_reduce_ns\":0"));
+        assertTrue(json.contains("\"serialize_ns\":0"));
+        assertTrue(json.contains("\"deserialize_ns\":0"));
+    }
+
+    public void testToXContentFieldNaming() throws IOException {
+
+        CoordinatorProfileInfo profile = new CoordinatorProfileInfo("test", 1L, 2L, 3L, 4L, 5L);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        profile.toXContent(builder, null);
+        builder.endObject();
+
+        String json = builder.toString();
+        assertTrue(json.contains("reduce_time_ns"));
+        assertTrue(json.contains("total_profiled_stages_time_ns"));
+        assertTrue(json.contains("internal_reduce_ns"));
+        assertTrue(json.contains("serialize_ns"));
+        assertTrue(json.contains("deserialize_ns"));
+    }
+}

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesWithCoordinatorProfileTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/InternalTimeSeriesWithCoordinatorProfileTests.java
@@ -1,0 +1,286 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.aggregator;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.aggregations.InternalAggregation;
+import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link InternalTimeSeriesWithCoordinatorProfile}.
+ *
+ * <p>This test class focuses on the profiling-specific functionality added by
+ * InternalTimeSeriesWithCoordinatorProfile. Tests for inherited behavior from
+ * InternalTimeSeries are covered in InternalTimeSeriesTests.</p>
+ */
+public class InternalTimeSeriesWithCoordinatorProfileTests extends OpenSearchTestCase {
+
+    private static final String TEST_NAME = "test-profiled-time-series";
+
+    // ========== Constructor Tests (Profiling-Specific) ==========
+
+    public void testConstructorWithProfileInfo() {
+
+        CoordinatorProfileInfo profileInfo = createProfileInfo("test_stages", 1000L);
+
+        InternalTimeSeriesWithCoordinatorProfile result = new InternalTimeSeriesWithCoordinatorProfile(
+            TEST_NAME,
+            List.of(),
+            Map.of(),
+            null,
+            profileInfo
+        );
+
+        assertEquals(profileInfo, result.getCoordinatorProfileInfo());
+        assertEquals(0L, result.getSerializeTimeNanos());
+        assertEquals(0L, result.getDeserializeTimeNanos());
+    }
+
+    public void testConstructorWithNullProfileInfo() {
+
+        InternalTimeSeriesWithCoordinatorProfile result = new InternalTimeSeriesWithCoordinatorProfile(
+            TEST_NAME,
+            List.of(),
+            Map.of(),
+            null,
+            null
+        );
+
+        assertNull(result.getCoordinatorProfileInfo());
+    }
+
+    public void testConstructorWith7ParametersIncludesExecStatsAndDataSource() {
+
+        AggregationExecStats execStats = new AggregationExecStats(1L, 2L, 3L, 4L, 5L, 6L, 7L);
+        AggregationDataSource dataSource = AggregationDataSource.EMPTY;
+        CoordinatorProfileInfo profileInfo = createProfileInfo("stages", 1000L);
+
+        InternalTimeSeriesWithCoordinatorProfile result = new InternalTimeSeriesWithCoordinatorProfile(
+            TEST_NAME,
+            List.of(),
+            Map.of(),
+            null,
+            execStats,
+            dataSource,
+            profileInfo
+        );
+
+        assertEquals(profileInfo, result.getCoordinatorProfileInfo());
+        assertEquals(execStats, result.getExecStats());
+        assertEquals(dataSource, result.getDataSource());
+    }
+
+    // ========== Writeable Name Test (Override Verification) ==========
+
+    public void testGetWriteableNameDiffersFromParent() {
+
+        InternalTimeSeriesWithCoordinatorProfile profiled = createResult(TEST_NAME);
+        InternalTimeSeries standard = new InternalTimeSeries(TEST_NAME, List.of(), Map.of());
+
+        assertEquals("time_series_with_coordinator_profile", profiled.getWriteableName());
+        assertEquals("time_series", standard.getWriteableName());
+        assertNotEquals(standard.getWriteableName(), profiled.getWriteableName());
+    }
+
+    // ========== Serialization Tests (Profiling-Specific) ==========
+
+    public void testSerializationWithProfileInfo() throws IOException {
+
+        CoordinatorProfileInfo profileInfo = createProfileInfo("mock: 500ns;scale: 300ns", 1500L);
+        InternalTimeSeriesWithCoordinatorProfile original = new InternalTimeSeriesWithCoordinatorProfile(
+            "test_ser",
+            List.of(),
+            Map.of("key", "value"),
+            null,
+            profileInfo
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        InternalTimeSeriesWithCoordinatorProfile deserialized = new InternalTimeSeriesWithCoordinatorProfile(in);
+
+        assertEquals(original.getName(), deserialized.getName());
+        assertNotNull(deserialized.getCoordinatorProfileInfo());
+        assertEquals(original.getCoordinatorProfileInfo().getStages(), deserialized.getCoordinatorProfileInfo().getStages());
+    }
+
+    public void testSerializationWithNullProfileInfo() throws IOException {
+
+        InternalTimeSeriesWithCoordinatorProfile original = new InternalTimeSeriesWithCoordinatorProfile(
+            "test_null",
+            List.of(),
+            Map.of(),
+            null,
+            null
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        InternalTimeSeriesWithCoordinatorProfile deserialized = new InternalTimeSeriesWithCoordinatorProfile(in);
+
+        assertNull(deserialized.getCoordinatorProfileInfo());
+    }
+
+    public void testSerializationCapturesTimings() throws IOException {
+
+        InternalTimeSeriesWithCoordinatorProfile original = createResult("timing_test");
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        InternalTimeSeriesWithCoordinatorProfile deserialized = new InternalTimeSeriesWithCoordinatorProfile(in);
+
+        // Note: serialize time from original is not preserved, timing happens per serialization
+        assertTrue("Deserialize time should be captured", deserialized.getDeserializeTimeNanos() >= 0);
+    }
+
+    // ========== XContent Tests (Override Verification) ==========
+
+    public void testDoXContentBodyIncludesCoordinatorProfile() throws IOException {
+
+        CoordinatorProfileInfo profileInfo = new CoordinatorProfileInfo("mockFetch: 1000ns;scale: 500ns", 2000L, 1500L, 500L, 300L, 200L);
+
+        InternalTimeSeriesWithCoordinatorProfile result = new InternalTimeSeriesWithCoordinatorProfile(
+            "test",
+            List.of(),
+            Map.of(),
+            null,
+            profileInfo
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        result.doXContentBody(builder, null);
+        builder.endObject();
+
+        String json = builder.toString();
+        assertTrue("Should contain coordinator_profile", json.contains("coordinator_profile"));
+        assertTrue("Should contain stages", json.contains("mockFetch: 1000ns"));
+        assertTrue("Should contain reduce_time_ns", json.contains("reduce_time_ns"));
+    }
+
+    public void testDoXContentBodyWithoutProfileExcludesCoordinatorProfile() throws IOException {
+
+        InternalTimeSeriesWithCoordinatorProfile result = new InternalTimeSeriesWithCoordinatorProfile(
+            "test",
+            List.of(),
+            Map.of(),
+            null,
+            null
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        result.doXContentBody(builder, null);
+        builder.endObject();
+
+        String json = builder.toString();
+        assertFalse("Should not contain coordinator_profile when null", json.contains("coordinator_profile"));
+    }
+
+    // ========== Reduce Tests (Override Verification) ==========
+
+    public void testReducePartialDelegatesToParent() {
+
+        List<InternalAggregation> aggregations = List.of(createResult("test1"), createResult("test2"));
+        PipelineAggregator.PipelineTree emptyTree = new PipelineAggregator.PipelineTree(Collections.emptyMap(), Collections.emptyList());
+        InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forPartialReduction(null, null, () -> emptyTree);
+
+        InternalTimeSeriesWithCoordinatorProfile first = (InternalTimeSeriesWithCoordinatorProfile) aggregations.get(0);
+        InternalAggregation result = first.reduce(aggregations, context);
+
+        assertNotNull(result);
+    }
+
+    public void testReduceFinalCreatesProfilingResult() {
+
+        CoordinatorProfileInfo profile1 = createProfileInfo("stage1", 1000L);
+        CoordinatorProfileInfo profile2 = createProfileInfo("stage2", 2000L);
+
+        List<InternalAggregation> aggregations = List.of(
+            new InternalTimeSeriesWithCoordinatorProfile("test1", List.of(), Map.of(), null, profile1),
+            new InternalTimeSeriesWithCoordinatorProfile("test2", List.of(), Map.of(), null, profile2)
+        );
+
+        PipelineAggregator.PipelineTree emptyTree = new PipelineAggregator.PipelineTree(Collections.emptyMap(), Collections.emptyList());
+        InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(null, null, s -> {}, emptyTree);
+
+        InternalTimeSeriesWithCoordinatorProfile first = (InternalTimeSeriesWithCoordinatorProfile) aggregations.get(0);
+        InternalAggregation result = first.reduce(aggregations, context);
+
+        assertTrue("Should return InternalTimeSeriesWithCoordinatorProfile", result instanceof InternalTimeSeriesWithCoordinatorProfile);
+        InternalTimeSeriesWithCoordinatorProfile profiledResult = (InternalTimeSeriesWithCoordinatorProfile) result;
+        assertNotNull("Should have coordinator profile info", profiledResult.getCoordinatorProfileInfo());
+    }
+
+    public void testReduceFinalAggregatesSerializationTimings() {
+
+        // Note: In real usage, these times are captured during actual serialization,
+        // but for unit testing we verify the aggregation logic
+        CoordinatorProfileInfo profile1 = createProfileInfo("stage1", 1000L);
+        CoordinatorProfileInfo profile2 = createProfileInfo("stage2", 2000L);
+
+        List<InternalAggregation> aggregations = List.of(
+            new InternalTimeSeriesWithCoordinatorProfile("test1", List.of(), Map.of(), null, profile1),
+            new InternalTimeSeriesWithCoordinatorProfile("test2", List.of(), Map.of(), null, profile2)
+        );
+
+        PipelineAggregator.PipelineTree emptyTree = new PipelineAggregator.PipelineTree(Collections.emptyMap(), Collections.emptyList());
+        InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(null, null, s -> {}, emptyTree);
+
+        InternalTimeSeriesWithCoordinatorProfile first = (InternalTimeSeriesWithCoordinatorProfile) aggregations.get(0);
+        InternalAggregation result = first.reduce(aggregations, context);
+
+        assertTrue(result instanceof InternalTimeSeriesWithCoordinatorProfile);
+        InternalTimeSeriesWithCoordinatorProfile profiledResult = (InternalTimeSeriesWithCoordinatorProfile) result;
+        assertNotNull("Should have aggregated profile info", profiledResult.getCoordinatorProfileInfo());
+        assertTrue("Should have internal reduce time", profiledResult.getCoordinatorProfileInfo().getInternalReduceTimeNanos() >= 0);
+    }
+
+    // ========== Inheritance Verification ==========
+
+    public void testInstanceOfParentClass() {
+
+        InternalTimeSeriesWithCoordinatorProfile result = createResult("test");
+
+        assertTrue("Should be instance of InternalTimeSeries", result instanceof InternalTimeSeries);
+    }
+
+    public void testInheritsParentBehavior() {
+
+        InternalTimeSeriesWithCoordinatorProfile result = createResult("inherited_test");
+
+        assertEquals("inherited_test", result.getName());
+        assertNotNull(result.getTimeSeries());
+        assertEquals(AggregationExecStats.EMPTY, result.getExecStats());
+        assertEquals(AggregationDataSource.EMPTY, result.getDataSource());
+    }
+
+    // ========== Helper Methods ==========
+
+    private InternalTimeSeriesWithCoordinatorProfile createResult(String name) {
+        return new InternalTimeSeriesWithCoordinatorProfile(name, List.of(), Map.of(), null, createProfileInfo("test_stages", 1000L));
+    }
+
+    private CoordinatorProfileInfo createProfileInfo(String stages, long reduceTimeNanos) {
+        return new CoordinatorProfileInfo(stages, reduceTimeNanos, 500L, 200L, 0L, 0L);
+    }
+}

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/ProfilingTimeSeriesCoordinatorAggregationBuilderTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/ProfilingTimeSeriesCoordinatorAggregationBuilderTests.java
@@ -1,0 +1,326 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.tsdb.query.aggregator;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.tsdb.lang.m3.stage.ScaleStage;
+import org.opensearch.tsdb.query.stage.PipelineStage;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ProfilingTimeSeriesCoordinatorAggregationBuilder}.
+ *
+ * <p>This test class focuses on the profiling-specific functionality added by
+ * ProfilingTimeSeriesCoordinatorAggregationBuilder. Tests for inherited behavior from
+ * TimeSeriesCoordinatorAggregationBuilder are covered in TimeSeriesCoordinatorAggregationBuilderTests.</p>
+ */
+public class ProfilingTimeSeriesCoordinatorAggregationBuilderTests extends OpenSearchTestCase {
+
+    // ========== Constructor Tests ==========
+
+    public void testConstructorBasic() {
+
+        String name = "test_profiling_agg";
+        List<PipelineStage> stages = List.of();
+        LinkedHashMap<String, TimeSeriesCoordinatorAggregator.MacroDefinition> macros = new LinkedHashMap<>();
+        Map<String, String> references = Map.of();
+        String inputReference = "input_ref";
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            name,
+            stages,
+            macros,
+            references,
+            inputReference
+        );
+
+        assertEquals(name, builder.getName());
+        assertEquals(ProfilingTimeSeriesCoordinatorAggregationBuilder.NAME, builder.getType());
+        assertEquals(ProfilingTimeSeriesCoordinatorAggregationBuilder.NAME, builder.getWriteableName());
+    }
+
+    public void testConstructorWithStagesAndReferences() {
+
+        List<PipelineStage> stages = List.of(new ScaleStage(2.0));
+        Map<String, String> references = Map.of("ref1", "agg1", "ref2", "agg2");
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            "test_with_stages",
+            stages,
+            new LinkedHashMap<>(),
+            references,
+            "ref1"
+        );
+
+        assertEquals("test_with_stages", builder.getName());
+        assertEquals(1, builder.getStages().size());
+        assertEquals(2, builder.getReferences().size());
+        assertEquals("ref1", builder.getInputReference());
+    }
+
+    // ========== Type and Name Tests (Override Verification) ==========
+
+    public void testGetTypeDiffersFromParent() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder profilingBuilder = createBuilder("test");
+        TimeSeriesCoordinatorAggregationBuilder standardBuilder = new TimeSeriesCoordinatorAggregationBuilder(
+            "test",
+            List.of(),
+            new LinkedHashMap<>(),
+            Map.of(),
+            null
+        );
+
+        assertEquals("coordinator_pipeline_with_profile", profilingBuilder.getType());
+        assertEquals("coordinator_pipeline", standardBuilder.getType());
+        assertNotEquals(standardBuilder.getType(), profilingBuilder.getType());
+    }
+
+    public void testGetWriteableNameDiffersFromParent() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder profilingBuilder = createBuilder("test");
+        TimeSeriesCoordinatorAggregationBuilder standardBuilder = new TimeSeriesCoordinatorAggregationBuilder(
+            "test",
+            List.of(),
+            new LinkedHashMap<>(),
+            Map.of(),
+            null
+        );
+
+        assertEquals("coordinator_pipeline_with_profile", profilingBuilder.getWriteableName());
+        assertEquals("coordinator_pipeline", standardBuilder.getWriteableName());
+        assertNotEquals(standardBuilder.getWriteableName(), profilingBuilder.getWriteableName());
+    }
+
+    public void testNameConstant() {
+
+        assertEquals("coordinator_pipeline_with_profile", ProfilingTimeSeriesCoordinatorAggregationBuilder.NAME);
+    }
+
+    // ========== createInternal Tests (Override Verification) ==========
+
+    public void testCreateInternalAddsProfilingFlag() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = createBuilder("test");
+
+        PipelineAggregator aggregator = builder.createInternal(null);
+
+        assertNotNull(aggregator);
+        assertTrue(aggregator instanceof TimeSeriesCoordinatorAggregator);
+        assertEquals("test", aggregator.name());
+    }
+
+    public void testCreateInternalPreservesExistingMetadata() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = createBuilder("test");
+        Map<String, Object> existingMetadata = Map.of("custom_key", "custom_value", "number", 42);
+
+        PipelineAggregator aggregator = builder.createInternal(existingMetadata);
+
+        assertNotNull(aggregator);
+        assertTrue(aggregator instanceof TimeSeriesCoordinatorAggregator);
+    }
+
+    public void testCreateInternalWithNullMetadata() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = createBuilder("test_null_meta");
+
+        PipelineAggregator aggregator = builder.createInternal(null);
+
+        assertNotNull(aggregator);
+        assertTrue(aggregator instanceof TimeSeriesCoordinatorAggregator);
+    }
+
+    public void testCreateInternalWithEmptyMetadata() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = createBuilder("test_empty_meta");
+
+        PipelineAggregator aggregator = builder.createInternal(Map.of());
+
+        assertNotNull(aggregator);
+        assertTrue(aggregator instanceof TimeSeriesCoordinatorAggregator);
+    }
+
+    // ========== Serialization Tests ==========
+
+    public void testSerializationBasic() throws IOException {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder original = createBuilder("test_ser");
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ProfilingTimeSeriesCoordinatorAggregationBuilder deserialized = new ProfilingTimeSeriesCoordinatorAggregationBuilder(in);
+
+        assertEquals(original.getName(), deserialized.getName());
+        assertEquals(original.getType(), deserialized.getType());
+        assertEquals(original.getWriteableName(), deserialized.getWriteableName());
+        assertEquals(original.getStages().size(), deserialized.getStages().size());
+        assertEquals(original.getReferences(), deserialized.getReferences());
+        assertEquals(original.getInputReference(), deserialized.getInputReference());
+    }
+
+    public void testSerializationWithReferences() throws IOException {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder original = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            "test_with_refs",
+            List.of(),
+            new LinkedHashMap<>(),
+            Map.of("ref1", "agg1", "ref2", "agg2"),
+            "input"
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        ProfilingTimeSeriesCoordinatorAggregationBuilder deserialized = new ProfilingTimeSeriesCoordinatorAggregationBuilder(in);
+
+        assertEquals(original.getName(), deserialized.getName());
+        assertEquals(original.getReferences(), deserialized.getReferences());
+        assertEquals("input", deserialized.getInputReference());
+    }
+
+    public void testSerializationRoundTrip() throws IOException {
+
+        for (int i = 0; i < 5; i++) {
+            ProfilingTimeSeriesCoordinatorAggregationBuilder original = createBuilder("test_" + i);
+
+            BytesStreamOutput out = new BytesStreamOutput();
+            original.writeTo(out);
+            StreamInput in = out.bytes().streamInput();
+            ProfilingTimeSeriesCoordinatorAggregationBuilder deserialized = new ProfilingTimeSeriesCoordinatorAggregationBuilder(in);
+
+            assertEquals("Round trip " + i, original.getName(), deserialized.getName());
+            assertEquals("Round trip " + i, original.getType(), deserialized.getType());
+        }
+    }
+
+    // ========== XContent Tests ==========
+
+    public void testXContentGeneration() throws IOException {
+
+        List<PipelineStage> stages = List.of(new ScaleStage(2.0));
+        Map<String, String> references = Map.of("a", "unfold_a", "b", "unfold_b");
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            "test_xcontent",
+            stages,
+            new LinkedHashMap<>(),
+            references,
+            "a"
+        );
+
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        xContentBuilder.startObject();
+        builder.internalXContent(xContentBuilder, null);
+        xContentBuilder.endObject();
+
+        String jsonString = xContentBuilder.toString();
+        assertNotNull(jsonString);
+        assertTrue(jsonString.contains("stages"));
+        assertTrue(jsonString.contains("references"));
+        assertTrue(jsonString.contains("inputReference"));
+    }
+
+    // ========== Inheritance Verification ==========
+
+    public void testInstanceOfParentClass() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = createBuilder("test");
+
+        assertTrue(
+            "Should be instance of TimeSeriesCoordinatorAggregationBuilder",
+            builder instanceof TimeSeriesCoordinatorAggregationBuilder
+        );
+    }
+
+    public void testInheritsParentBehavior() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = createBuilder("inherited_test");
+
+        assertEquals("inherited_test", builder.getName());
+        assertNotNull(builder.getStages());
+        assertNotNull(builder.getReferences());
+        assertNotNull(builder.getMacroDefinitions());
+    }
+
+    public void testDifferentInstancesHaveDistinctTypes() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder profiling1 = createBuilder("test1");
+        ProfilingTimeSeriesCoordinatorAggregationBuilder profiling2 = createBuilder("test2");
+        TimeSeriesCoordinatorAggregationBuilder standard = new TimeSeriesCoordinatorAggregationBuilder(
+            "test3",
+            List.of(),
+            new LinkedHashMap<>(),
+            Map.of(),
+            null
+        );
+
+        assertEquals(profiling1.getType(), profiling2.getType());
+        assertNotEquals(profiling1.getType(), standard.getType());
+        assertEquals("coordinator_pipeline_with_profile", profiling1.getType());
+        assertEquals("coordinator_pipeline", standard.getType());
+    }
+
+    // ========== Edge Cases ==========
+
+    public void testConstructorWithNullStages() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            "test_null_stages",
+            null,
+            new LinkedHashMap<>(),
+            Map.of(),
+            null
+        );
+
+        assertEquals("test_null_stages", builder.getName());
+    }
+
+    public void testConstructorWithNullReferences() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            "test_null_refs",
+            List.of(),
+            new LinkedHashMap<>(),
+            null,
+            null
+        );
+
+        assertEquals("test_null_refs", builder.getName());
+    }
+
+    public void testConstructorWithNullMacros() {
+
+        ProfilingTimeSeriesCoordinatorAggregationBuilder builder = new ProfilingTimeSeriesCoordinatorAggregationBuilder(
+            "test_null_macros",
+            List.of(),
+            null,
+            Map.of(),
+            null
+        );
+
+        assertEquals("test_null_macros", builder.getName());
+    }
+
+    // ========== Helper Methods ==========
+
+    private ProfilingTimeSeriesCoordinatorAggregationBuilder createBuilder(String name) {
+        return new ProfilingTimeSeriesCoordinatorAggregationBuilder(name, List.of(), new LinkedHashMap<>(), Map.of(), null);
+    }
+}

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregatorTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TimeSeriesCoordinatorAggregatorTests.java
@@ -152,4 +152,66 @@ public class TimeSeriesCoordinatorAggregatorTests extends OpenSearchTestCase {
         assertTrue(mergedDs.indexes().contains(new AggregationDataSource.IndexInfo("2d", "10s")));
         assertTrue(mergedDs.indexes().contains(new AggregationDataSource.IndexInfo("30d", "1m")));
     }
+
+    // ========== Profiling Tests ==========
+
+    public void testDoReduceWithProfilingEnabled() {
+        Map<String, Object> metadata = Map.of("_enable_coordinator_profiling", true);
+
+        TimeSeries oneSeries = new TimeSeries(
+            List.of(new FloatSample(1000L, 10.0)),
+            ByteLabels.fromMap(Map.of("x", "y")),
+            1000L,
+            1000L,
+            1000L,
+            "s1"
+        );
+        InternalTimeSeries unfoldAgg = new InternalTimeSeries("unfold_a", List.of(oneSeries), Map.of());
+
+        TimeSeriesCoordinatorAggregator aggregator = new TimeSeriesCoordinatorAggregator(
+            "test_profiling",
+            new String[0],
+            Collections.emptyList(),
+            new LinkedHashMap<>(),
+            Map.of("a", "unfold_a"),
+            "a",
+            metadata
+        );
+
+        Aggregations aggregations = new Aggregations(List.of(unfoldAgg));
+        PipelineAggregator.PipelineTree emptyTree = new PipelineAggregator.PipelineTree(Collections.emptyMap(), Collections.emptyList());
+        InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(null, null, s -> {}, emptyTree);
+
+        InternalAggregation result = aggregator.doReduce(aggregations, context);
+
+        assertTrue("Should return InternalTimeSeriesWithCoordinatorProfile", result instanceof InternalTimeSeriesWithCoordinatorProfile);
+
+        InternalTimeSeriesWithCoordinatorProfile profiledResult = (InternalTimeSeriesWithCoordinatorProfile) result;
+        assertNotNull("Should have coordinator profile info", profiledResult.getCoordinatorProfileInfo());
+    }
+
+    public void testDoReduceWithProfilingEnabledButEmptyResult() {
+        Map<String, Object> metadata = Map.of("_enable_coordinator_profiling", true);
+
+        TimeSeriesCoordinatorAggregator aggregator = new TimeSeriesCoordinatorAggregator(
+            "test_empty_profiling",
+            new String[0],
+            Collections.emptyList(),
+            new LinkedHashMap<>(),
+            Map.of(),
+            null,
+            metadata
+        );
+
+        Aggregations aggregations = new Aggregations(Collections.emptyList());
+        PipelineAggregator.PipelineTree emptyTree = new PipelineAggregator.PipelineTree(Collections.emptyMap(), Collections.emptyList());
+        InternalAggregation.ReduceContext context = InternalAggregation.ReduceContext.forFinalReduction(null, null, s -> {}, emptyTree);
+
+        InternalAggregation result = aggregator.doReduce(aggregations, context);
+
+        assertTrue(
+            "Should return InternalTimeSeriesWithCoordinatorProfile for empty result with profiling",
+            result instanceof InternalTimeSeriesWithCoordinatorProfile
+        );
+    }
 }

--- a/src/test/java/org/opensearch/tsdb/query/utils/StageProfilerTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/utils/StageProfilerTests.java
@@ -29,4 +29,38 @@ public class StageProfilerTests extends OpenSearchTestCase {
         String expected = "stage_a(1): 10 ns, 100 bytes;" + "stage_b(2): 20 ns, 200 bytes";
         assertEquals(expected, profiler.getResults());
     }
+
+    public void testGetTotalTime() {
+
+        StageProfiler profiler = new StageProfiler();
+
+        profiler.record("stage_a", 1000L, 10L, 100L);
+        profiler.record("stage_b", 2000L, 20L, 200L);
+        profiler.record("stage_c", 3000L, 30L, 300L);
+
+        assertEquals("Total time should sum all stage latencies", 6000L, profiler.getTotalTime());
+    }
+
+    public void testGetTotalTimeEmptyProfiler() {
+
+        StageProfiler profiler = new StageProfiler();
+
+        assertEquals("Empty profiler should have zero total time", 0L, profiler.getTotalTime());
+    }
+
+    public void testRecordMultipleStages() {
+
+        StageProfiler profiler = new StageProfiler();
+
+        profiler.record("mockFetch", 500000L, 100L, 1024L);
+        profiler.record("scale", 300000L, 100L, 512L);
+        profiler.record("sum", 200000L, 50L, 256L);
+
+        String results = profiler.getResults();
+        assertTrue("Results should contain mockFetch", results.contains("mockFetch(100): 500000 ns, 1024 bytes"));
+        assertTrue("Results should contain scale", results.contains("scale(100): 300000 ns, 512 bytes"));
+        assertTrue("Results should contain sum", results.contains("sum(50): 200000 ns, 256 bytes"));
+
+        assertEquals("Total time should be sum of all stages", 1000000L, profiler.getTotalTime());
+    }
 }


### PR DESCRIPTION
### Description
This PR adds coordinator-level profiling support for M3QL queries, enabling performance analysis of pipeline stages that execute on the coordinator node (e.g., mockFetch, scale, count, topK, movingAverage, etc.). This PR creates
a new aggregation builder, **ProfilingTimeSeriesCoordinatorAggregationBuilder**,  that enables profiling when profile=true is set in the query. 


**Example Request**
```
curl -X POST "http://localhost:9200/_m3ql" \
  -H 'Content-Type: application/json' \
  -d '{
  "partitions": "metrics",
  "query": "mockFetch 10.0, 20.0, 30.0 | scale 2 | topK 5",
  "profile": true
}'

```

**Updated Response:**

```
{
  "profile": {
    "shards": [ /* shard-level profiling */ ],
    "coordinator": {
      "stages": "mockFetch(0): 1598625 ns, 0 bytes;scale(2): 399500 ns, 224 bytes;topK(2): 339125 ns, 0 bytes",
      "reduce_time_ns": 3299708,
      "total_profiled_stages_time_ns": 2337250,
      "internal_reduce_ns": 0,
      "serialize_ns": 0,
      "deserialize_ns": 0
    }
  }
}
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
