### PR TITLE
Add dedup_mode parameter to _tsdb/stats endpoint

### DIFF
--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregationBuilder.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregationBuilder.java
@@ -18,9 +18,11 @@ import org.opensearch.search.aggregations.AggregatorFactories.Builder;
 import org.opensearch.search.aggregations.AggregatorFactory;
 import org.opensearch.search.aggregations.support.ValuesSourceRegistry;
 import org.opensearch.tsdb.TSDBPlugin;
+import org.opensearch.tsdb.query.utils.TSDBStatsConstants;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Aggregation builder for TSDB statistics aggregations.
@@ -38,7 +40,7 @@ import java.util.Map;
  *
  * <h2>Usage Example:</h2>
  * <pre>{@code
- * TSDBStatsAggregationBuilder builder = new TSDBStatsAggregationBuilder("tsdb_stats", 1000000L, 2000000L, true);
+ * TSDBStatsAggregationBuilder builder = new TSDBStatsAggregationBuilder("tsdb_stats", 1000000L, 2000000L, true, "indexed");
  * }</pre>
  *
  * @since 0.0.1
@@ -50,6 +52,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
     private final long minTimestamp;
     private final long maxTimestamp;
     private final boolean includeValueStats;
+    private final String dedupMode;
 
     /**
      * Creates a TSDB stats aggregation builder.
@@ -58,9 +61,10 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
      * @param minTimestamp The minimum timestamp for filtering
      * @param maxTimestamp The maximum timestamp for filtering
      * @param includeValueStats Whether to include per-value statistics
+     * @param dedupMode The dedup mode ("indexed" or "recomputed")
      * @throws IllegalArgumentException if maxTimestamp is not greater than minTimestamp
      */
-    public TSDBStatsAggregationBuilder(String name, long minTimestamp, long maxTimestamp, boolean includeValueStats) {
+    public TSDBStatsAggregationBuilder(String name, long minTimestamp, long maxTimestamp, boolean includeValueStats, String dedupMode) {
         super(name);
 
         // Validate time range
@@ -73,6 +77,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         this.minTimestamp = minTimestamp;
         this.maxTimestamp = maxTimestamp;
         this.includeValueStats = includeValueStats;
+        this.dedupMode = dedupMode;
     }
 
     /**
@@ -86,6 +91,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         this.minTimestamp = in.readLong();
         this.maxTimestamp = in.readLong();
         this.includeValueStats = in.readBoolean();
+        this.dedupMode = in.readString();
     }
 
     /**
@@ -100,6 +106,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         this.minTimestamp = clone.minTimestamp;
         this.maxTimestamp = clone.maxTimestamp;
         this.includeValueStats = clone.includeValueStats;
+        this.dedupMode = clone.dedupMode;
     }
 
     @Override
@@ -107,6 +114,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         out.writeLong(minTimestamp);
         out.writeLong(maxTimestamp);
         out.writeBoolean(includeValueStats);
+        out.writeString(dedupMode);
     }
 
     @Override
@@ -115,6 +123,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         builder.field("min_timestamp", minTimestamp);
         builder.field("max_timestamp", maxTimestamp);
         builder.field("include_value_stats", includeValueStats);
+        builder.field("dedup_mode", dedupMode);
         builder.endObject();
         return builder;
     }
@@ -131,6 +140,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         Long minTimestamp = null;
         Long maxTimestamp = null;
         Boolean includeValueStats = null;
+        String dedupMode = TSDBStatsConstants.DEDUP_MODE_INDEXED;
 
         XContentParser.Token token;
         String currentFieldName = null;
@@ -148,6 +158,12 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
             } else if (token == XContentParser.Token.VALUE_BOOLEAN) {
                 if ("include_value_stats".equals(currentFieldName)) {
                     includeValueStats = parser.booleanValue();
+                } else {
+                    parser.skipChildren();
+                }
+            } else if (token == XContentParser.Token.VALUE_STRING) {
+                if ("dedup_mode".equals(currentFieldName)) {
+                    dedupMode = parser.text();
                 } else {
                     parser.skipChildren();
                 }
@@ -169,7 +185,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
             );
         }
 
-        return new TSDBStatsAggregationBuilder(aggregationName, minTimestamp, maxTimestamp, includeValueStats);
+        return new TSDBStatsAggregationBuilder(aggregationName, minTimestamp, maxTimestamp, includeValueStats, dedupMode);
     }
 
     @Override
@@ -192,7 +208,8 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
             metadata,
             minTimestamp,
             maxTimestamp,
-            includeValueStats
+            includeValueStats,
+            dedupMode
         );
     }
 
@@ -219,7 +236,10 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         }
 
         TSDBStatsAggregationBuilder that = (TSDBStatsAggregationBuilder) obj;
-        return minTimestamp == that.minTimestamp && maxTimestamp == that.maxTimestamp && includeValueStats == that.includeValueStats;
+        return minTimestamp == that.minTimestamp
+            && maxTimestamp == that.maxTimestamp
+            && includeValueStats == that.includeValueStats
+            && Objects.equals(dedupMode, that.dedupMode);
     }
 
     @Override
@@ -228,6 +248,7 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
         result = 31 * result + Long.hashCode(minTimestamp);
         result = 31 * result + Long.hashCode(maxTimestamp);
         result = 31 * result + Boolean.hashCode(includeValueStats);
+        result = 31 * result + Objects.hashCode(dedupMode);
         return result;
     }
 
@@ -256,6 +277,15 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
      */
     public boolean isIncludeValueStats() {
         return includeValueStats;
+    }
+
+    /**
+     * Gets the dedup mode.
+     *
+     * @return the dedup mode string ("indexed" or "recomputed")
+     */
+    public String getDedupMode() {
+        return dedupMode;
     }
 
     /**

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregationBuilder.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregationBuilder.java
@@ -62,6 +62,10 @@ public class TSDBStatsAggregationBuilder extends AbstractAggregationBuilder<TSDB
      * @param maxTimestamp The maximum timestamp for filtering
      * @param includeValueStats Whether to include per-value statistics
      * @param dedupMode The dedup mode ("indexed" or "recomputed")
+     *                  "indexed": Reads pre-indexed numeric value from NumericDocValues (reference for LSI,
+     *                             labels_hash for CCI), avoiding binary label decoding for duplicate series.
+     *                  "recomputed": Decodes labels and calls stableHash() (existing behavior), useful during
+     *                                hash algorithm migrations.
      * @throws IllegalArgumentException if maxTimestamp is not greater than minTimestamp
      */
     public TSDBStatsAggregationBuilder(String name, long minTimestamp, long maxTimestamp, boolean includeValueStats, String dedupMode) {

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregator.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregator.java
@@ -10,6 +10,7 @@ package org.opensearch.tsdb.query.aggregator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.util.ByteBlockPool;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefHash;
@@ -19,9 +20,13 @@ import org.opensearch.search.aggregations.LeafBucketCollector;
 import org.opensearch.search.aggregations.LeafBucketCollectorBase;
 import org.opensearch.search.aggregations.metrics.MetricsAggregator;
 import org.opensearch.search.internal.SearchContext;
+import org.opensearch.tsdb.core.index.closed.ClosedChunkIndexLeafReader;
+import org.opensearch.tsdb.core.index.live.LiveSeriesIndexLeafReader;
+import org.opensearch.tsdb.core.mapping.Constants;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.reader.TSDBDocValues;
 import org.opensearch.tsdb.core.reader.TSDBLeafReader;
+import org.opensearch.tsdb.query.utils.TSDBStatsConstants;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -51,6 +56,7 @@ public class TSDBStatsAggregator extends MetricsAggregator {
     private final long minTimestamp;
     private final long maxTimestamp;
     private final boolean includeValueStats;
+    private final String dedupMode;
 
     // Series identifiers (reference or labels_hash) we've already processed
     // TODO limit unbounded memory usage
@@ -74,6 +80,7 @@ public class TSDBStatsAggregator extends MetricsAggregator {
      * @param minTimestamp The minimum timestamp for filtering
      * @param maxTimestamp The maximum timestamp for filtering
      * @param includeValueStats Whether to include per-value statistics
+     * @param dedupMode The dedup mode ("indexed" or "recomputed")
      * @param metadata The aggregation metadata
      * @throws IOException If an error occurs during initialization
      */
@@ -84,12 +91,14 @@ public class TSDBStatsAggregator extends MetricsAggregator {
         long minTimestamp,
         long maxTimestamp,
         boolean includeValueStats,
+        String dedupMode,
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
         this.minTimestamp = minTimestamp;
         this.maxTimestamp = maxTimestamp;
         this.includeValueStats = includeValueStats;
+        this.dedupMode = dedupMode;
 
         this.seenSeriesIds = new HashSet<>();
 
@@ -117,27 +126,70 @@ public class TSDBStatsAggregator extends MetricsAggregator {
     private class TSDBStatsLeafBucketCollector extends LeafBucketCollectorBase {
 
         private final TSDBLeafReader tsdbLeafReader;
-        private TSDBDocValues tsdbDocValues;
+        private final TSDBDocValues tsdbDocValues;
+        private final NumericDocValues seriesIdDocValues;
 
         public TSDBStatsLeafBucketCollector(LeafReaderContext ctx, TSDBLeafReader tsdbLeafReader, LeafBucketCollector sub)
             throws IOException {
             super(sub, null);
             this.tsdbLeafReader = tsdbLeafReader;
             this.tsdbDocValues = this.tsdbLeafReader.getTSDBDocValues();
+
+            if (TSDBStatsConstants.DEDUP_MODE_INDEXED.equals(dedupMode)) {
+                // Determine the field name for the pre-indexed seriesId based on reader type.
+                // For LSI (LiveSeriesIndex), the seriesId is stored as "reference" in NumericDocValues.
+                // For CCI (ClosedChunkIndex), the seriesId is stored as "labels_hash" in NumericDocValues.
+                // ASSUMPTION: reference == labels_hash for cross-segment dedup correctness.
+                // reference in LSI is seriesID, labels_hash in CCI is labels.stableHash() used for sorting.
+                // We assume reference == labels_hash. If in the future reference != labels_hash,
+                // we need to fix how we read indexed reference from CCI.
+                String fieldName;
+                if (tsdbLeafReader instanceof LiveSeriesIndexLeafReader) {
+                    fieldName = Constants.IndexSchema.REFERENCE;
+                } else if (tsdbLeafReader instanceof ClosedChunkIndexLeafReader) {
+                    fieldName = Constants.IndexSchema.LABELS_HASH;
+                } else {
+                    throw new IOException("Unsupported TSDBLeafReader type for indexed dedup: " + tsdbLeafReader.getClass().getName());
+                }
+                this.seriesIdDocValues = tsdbLeafReader.getNumericDocValues(fieldName);
+                if (this.seriesIdDocValues == null) {
+                    throw new IOException("NumericDocValues field '" + fieldName + "' not found");
+                }
+            } else {
+                this.seriesIdDocValues = null;
+            }
         }
 
         @Override
         public void collect(int doc, long bucket) throws IOException {
-            Labels labels = tsdbLeafReader.labelsForDoc(doc, tsdbDocValues);
-            // We assume labels hash is the seriesId
-            // This need to be changed when we start accepting reference/seriesId from indexing
-            // Currently we by default use BytesLabels which uses 64-bit MurmurHash3 for series identity.
-            // Collision probability is ~n²/2^65: ~1 in 37M for 1M series, ~1 in 370 for 1B series.
-            // Acceptable for stats counting.
-            long seriesId = labels.stableHash();
-            // Already processed this series - skip entire document
-            if (!seenSeriesIds.add(seriesId)) {
-                return;
+            Labels labels;
+            long seriesId;
+
+            if (TSDBStatsConstants.DEDUP_MODE_INDEXED.equals(dedupMode)) {
+                // Fast path: read pre-indexed seriesId from NumericDocValues.
+                // For LSI this reads the "reference" field; for CCI this reads the "labels_hash" field.
+                // ASSUMPTION: reference == labels_hash for cross-segment dedup correctness.
+                // If this assumption breaks (e.g., during hash algorithm migration), use dedup_mode=recomputed.
+                if (!seriesIdDocValues.advanceExact(doc)) {
+                    throw new IOException("SeriesId not found for doc " + doc);
+                }
+                seriesId = seriesIdDocValues.longValue();
+                if (!seenSeriesIds.add(seriesId)) {
+                    return; // Skip without decoding labels -- fast!
+                }
+                labels = tsdbLeafReader.labelsForDoc(doc, tsdbDocValues);
+            } else {
+                // Slow path: decode labels and compute hash
+                labels = tsdbLeafReader.labelsForDoc(doc, tsdbDocValues);
+                // We assume labels hash is the seriesId
+                // Currently we by default use BytesLabels which uses 64-bit MurmurHash3 for series identity.
+                // Collision probability is ~n^2/2^65: ~1 in 37M for 1M series, ~1 in 370 for 1B series.
+                // Acceptable for stats counting.
+                seriesId = labels.stableHash();
+                // Already processed this series - skip entire document
+                if (!seenSeriesIds.add(seriesId)) {
+                    return;
+                }
             }
 
             // TODO process each label using BytesRef directly (avoid String conversion)

--- a/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorFactory.java
+++ b/src/main/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorFactory.java
@@ -44,6 +44,7 @@ public class TSDBStatsAggregatorFactory extends AggregatorFactory {
     private final long minTimestamp;
     private final long maxTimestamp;
     private final boolean includeValueStats;
+    private final String dedupMode;
 
     /**
      * Creates a TSDB stats aggregator factory.
@@ -56,6 +57,7 @@ public class TSDBStatsAggregatorFactory extends AggregatorFactory {
      * @param minTimestamp The minimum timestamp for filtering
      * @param maxTimestamp The maximum timestamp for filtering
      * @param includeValueStats Whether to include per-value statistics
+     * @param dedupMode The dedup mode ("indexed" or "recomputed")
      * @throws IOException If an error occurs during initialization
      */
     public TSDBStatsAggregatorFactory(
@@ -66,12 +68,14 @@ public class TSDBStatsAggregatorFactory extends AggregatorFactory {
         Map<String, Object> metadata,
         long minTimestamp,
         long maxTimestamp,
-        boolean includeValueStats
+        boolean includeValueStats,
+        String dedupMode
     ) throws IOException {
         super(name, queryShardContext, parent, subFactoriesBuilder, metadata);
         this.minTimestamp = minTimestamp;
         this.maxTimestamp = maxTimestamp;
         this.includeValueStats = includeValueStats;
+        this.dedupMode = dedupMode;
     }
 
     @Override
@@ -81,7 +85,7 @@ public class TSDBStatsAggregatorFactory extends AggregatorFactory {
         CardinalityUpperBound cardinality,
         Map<String, Object> metadata
     ) throws IOException {
-        return new TSDBStatsAggregator(name, searchContext, parent, minTimestamp, maxTimestamp, includeValueStats, metadata);
+        return new TSDBStatsAggregator(name, searchContext, parent, minTimestamp, maxTimestamp, includeValueStats, dedupMode, metadata);
     }
 
     @Override

--- a/src/main/java/org/opensearch/tsdb/query/rest/RestTSDBStatsAction.java
+++ b/src/main/java/org/opensearch/tsdb/query/rest/RestTSDBStatsAction.java
@@ -84,6 +84,7 @@ import static org.opensearch.tsdb.query.utils.TSDBStatsConstants.AGGREGATION_NAM
  *   <li><b>format</b> (optional): Response format. Valid values: grouped, flat (default: grouped)</li>
  *   <li><b>partitions</b> (optional): Comma-separated list of indices to query</li>
  *   <li><b>explain</b> (optional): Return translated DSL instead of executing (default: false)</li>
+ *   <li><b>dedup_mode</b> (optional): Deduplication mode. Valid values: indexed, recomputed (default: indexed)</li>
  * </ul>
  *
  * <h2>Response Formats:</h2>
@@ -165,6 +166,7 @@ public class RestTSDBStatsAction extends BaseTSDBAction {
     private static final String BASE_PATH = "/_tsdb/stats";
     private static final String INCLUDE_PARAM = "include";
     private static final String FORMAT_PARAM = "format";
+    private static final String DEDUP_MODE_PARAM = "dedup_mode";
     private static final String DEFAULT_START_TIME = "now-30m";
     private static final String DEFAULT_END_TIME = "now";
 
@@ -181,6 +183,11 @@ public class RestTSDBStatsAction extends BaseTSDBAction {
     // Valid format options (TreeSet for deterministic toString() order in error messages)
     private static final Set<String> VALID_FORMAT_OPTIONS = new TreeSet<>(
         Arrays.asList(TSDBStatsConstants.FORMAT_GROUPED, TSDBStatsConstants.FORMAT_FLAT)
+    );
+
+    // Valid dedup_mode options (TreeSet for deterministic toString() order in error messages)
+    private static final Set<String> VALID_DEDUP_MODE_OPTIONS = new TreeSet<>(
+        Arrays.asList(TSDBStatsConstants.DEDUP_MODE_INDEXED, TSDBStatsConstants.DEDUP_MODE_RECOMPUTED)
     );
 
     /**
@@ -263,6 +270,23 @@ public class RestTSDBStatsAction extends BaseTSDBAction {
         }
 
         return format;
+    }
+
+    /**
+     * Parses and validates the dedup_mode parameter.
+     *
+     * @param request the REST request
+     * @return the dedup mode value ("indexed" or "recomputed")
+     * @throws IllegalArgumentException if invalid dedup_mode is provided
+     */
+    private String parseDedupModeParam(RestRequest request) {
+        String dedupMode = request.param(DEDUP_MODE_PARAM, TSDBStatsConstants.DEDUP_MODE_INDEXED);
+
+        if (!VALID_DEDUP_MODE_OPTIONS.contains(dedupMode)) {
+            throw new IllegalArgumentException("Invalid dedup_mode: " + dedupMode + ". Valid options: " + VALID_DEDUP_MODE_OPTIONS);
+        }
+
+        return dedupMode;
     }
 
     /**
@@ -380,12 +404,14 @@ public class RestTSDBStatsAction extends BaseTSDBAction {
             return errorResponse("Start time must be before end time", RestStatus.BAD_REQUEST);
         }
 
-        // Parse include and format parameters with validation
+        // Parse include, format, and dedup_mode parameters with validation
         List<String> includeOptions;
         String format;
+        String dedupMode;
         try {
             includeOptions = parseIncludeParam(request);
             format = parseFormatParam(request);
+            dedupMode = parseDedupModeParam(request);
         } catch (IllegalArgumentException e) {
             return errorResponse(e.getMessage(), RestStatus.BAD_REQUEST);
         }
@@ -407,7 +433,13 @@ public class RestTSDBStatsAction extends BaseTSDBAction {
             QueryBuilder filter = buildQueryFromFetch(fetchPlan, startMs, endMs);
 
             // Build aggregation
-            TSDBStatsAggregationBuilder aggBuilder = new TSDBStatsAggregationBuilder(AGGREGATION_NAME, startMs, endMs, includeValueStats);
+            TSDBStatsAggregationBuilder aggBuilder = new TSDBStatsAggregationBuilder(
+                AGGREGATION_NAME,
+                startMs,
+                endMs,
+                includeValueStats,
+                dedupMode
+            );
 
             // Build search request
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(filter).aggregation(aggBuilder).size(0);

--- a/src/main/java/org/opensearch/tsdb/query/utils/TSDBStatsConstants.java
+++ b/src/main/java/org/opensearch/tsdb/query/utils/TSDBStatsConstants.java
@@ -26,4 +26,8 @@ public final class TSDBStatsConstants {
     // Format values
     public static final String FORMAT_GROUPED = "grouped";
     public static final String FORMAT_FLAT = "flat";
+
+    // Dedup mode values
+    public static final String DEDUP_MODE_INDEXED = "indexed";
+    public static final String DEDUP_MODE_RECOMPUTED = "recomputed";
 }

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/AggregatorTestUtils.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/AggregatorTestUtils.java
@@ -7,8 +7,8 @@
  */
 package org.opensearch.tsdb.query.aggregator;
 
-import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.CompositeReader;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
@@ -21,6 +21,11 @@ import org.apache.lucene.index.TermVectors;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.opensearch.tsdb.core.chunk.ChunkIterator;
+import org.opensearch.tsdb.core.index.closed.ClosedChunkIndexLeafReader;
+import org.opensearch.tsdb.core.index.live.LiveSeriesIndexLeafReader;
+import org.opensearch.tsdb.core.index.live.MemChunkReader;
+import org.opensearch.tsdb.core.mapping.Constants;
+import org.opensearch.tsdb.core.mapping.LabelStorageType;
 import org.opensearch.tsdb.core.model.ByteLabels;
 import org.opensearch.tsdb.core.model.Labels;
 import org.opensearch.tsdb.core.reader.TSDBDocValues;
@@ -103,24 +108,33 @@ public class AggregatorTestUtils {
     }
 
     /**
-     * Creates a mock TSDBLeafReader with specified labels.
-     * Uses ByteLabels.fromMap() to create real Labels with proper stableHash() for deduplication.
-     *
-     * @param minTimestamp Minimum timestamp for the reader
-     * @param maxTimestamp Maximum timestamp for the reader
-     * @param labelPairs Map of label key-value pairs (e.g., {"service": "api", "host": "server1"})
-     * @return TSDBLeafReaderWithContext containing the reader and associated resources
-     * @throws IOException If an error occurs during setup
+     * Creates a mock ClosedChunkIndexLeafReader with labels and a default seriesId of 0.
      */
-    public static TSDBLeafReaderWithContext createMockTSDBLeafReaderWithLabels(
+    public static TSDBLeafReaderWithContext createMockCCIReaderWithLabels(
         long minTimestamp,
         long maxTimestamp,
         Map<String, String> labelPairs
+    ) throws IOException {
+        return createMockCCIReaderWithLabels(minTimestamp, maxTimestamp, labelPairs, 0);
+    }
+
+    /**
+     * Creates a mock ClosedChunkIndexLeafReader with NumericDocValues and labels.
+     * The reader passes instanceof ClosedChunkIndexLeafReader checks and delegates
+     * getNumericDocValues to the real Lucene index (which contains the indexed field).
+     */
+    public static TSDBLeafReaderWithContext createMockCCIReaderWithLabels(
+        long minTimestamp,
+        long maxTimestamp,
+        Map<String, String> labelPairs,
+        long numericFieldValue
     ) throws IOException {
         Directory directory = new ByteBuffersDirectory();
         IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig());
 
         Document doc = new Document();
+        doc.add(new NumericDocValuesField(Constants.IndexSchema.LABELS_HASH, numericFieldValue));
+
         indexWriter.addDocument(doc);
         indexWriter.commit();
 
@@ -129,23 +143,12 @@ public class AggregatorTestUtils {
 
         Labels labels = labelPairs != null ? ByteLabels.fromMap(labelPairs) : null;
 
-        // Create TSDBLeafReader with mocked TSDB-specific methods
-        TSDBLeafReader tsdbLeafReader = new TSDBLeafReader(baseReader, minTimestamp, maxTimestamp) {
-            @Override
-            public CacheHelper getReaderCacheHelper() {
-                return null;
-            }
-
-            @Override
-            public CacheHelper getCoreCacheHelper() {
-                return null;
-            }
-
-            @Override
-            protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
-                return reader;
-            }
-
+        ClosedChunkIndexLeafReader cciReader = new ClosedChunkIndexLeafReader(
+            baseReader,
+            LabelStorageType.BINARY,
+            minTimestamp,
+            maxTimestamp
+        ) {
             @Override
             public TSDBDocValues getTSDBDocValues() throws IOException {
                 return mock(TSDBDocValues.class);
@@ -162,11 +165,74 @@ public class AggregatorTestUtils {
             }
         };
 
-        // Create a CompositeReader that wraps our TSDBLeafReader
-        CompositeReader compositeReader = createCompositeReaderWrapper(tsdbLeafReader);
+        CompositeReader compositeReader = createCompositeReaderWrapper(cciReader);
         LeafReaderContext context = compositeReader.leaves().get(0);
 
-        return new TSDBLeafReaderWithContext(tsdbLeafReader, context, compositeReader, tempReader, indexWriter, directory);
+        return new TSDBLeafReaderWithContext(cciReader, context, compositeReader, tempReader, indexWriter, directory);
+    }
+
+    /**
+     * Creates a mock LiveSeriesIndexLeafReader with labels and a default seriesId of 0.
+     */
+    public static TSDBLeafReaderWithContext createMockLSIReaderWithLabels(
+        long minTimestamp,
+        long maxTimestamp,
+        Map<String, String> labelPairs
+    ) throws IOException {
+        return createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labelPairs, 0);
+    }
+
+    /**
+     * Creates a mock LiveSeriesIndexLeafReader with NumericDocValues and labels.
+     * The reader passes instanceof LiveSeriesIndexLeafReader checks and delegates
+     * getNumericDocValues to the real Lucene index (which contains the indexed field).
+     */
+    public static TSDBLeafReaderWithContext createMockLSIReaderWithLabels(
+        long minTimestamp,
+        long maxTimestamp,
+        Map<String, String> labelPairs,
+        long numericFieldValue
+    ) throws IOException {
+        Directory directory = new ByteBuffersDirectory();
+        IndexWriter indexWriter = new IndexWriter(directory, new IndexWriterConfig());
+
+        Document doc = new Document();
+        doc.add(new NumericDocValuesField(Constants.IndexSchema.REFERENCE, numericFieldValue));
+        indexWriter.addDocument(doc);
+        indexWriter.commit();
+
+        DirectoryReader tempReader = DirectoryReader.open(indexWriter);
+        LeafReader baseReader = tempReader.leaves().get(0).reader();
+
+        Labels labels = labelPairs != null ? ByteLabels.fromMap(labelPairs) : null;
+
+        LiveSeriesIndexLeafReader lsiReader = new LiveSeriesIndexLeafReader(
+            baseReader,
+            mock(MemChunkReader.class),
+            LabelStorageType.BINARY,
+            minTimestamp,
+            Collections.emptyMap()
+        ) {
+            @Override
+            public TSDBDocValues getTSDBDocValues() throws IOException {
+                return mock(TSDBDocValues.class);
+            }
+
+            @Override
+            public List<ChunkIterator> chunksForDoc(int docId, TSDBDocValues tsdbDocValues) throws IOException {
+                return List.of();
+            }
+
+            @Override
+            public Labels labelsForDoc(int docId, TSDBDocValues tsdbDocValues) throws IOException {
+                return labels;
+            }
+        };
+
+        CompositeReader compositeReader = createCompositeReaderWrapper(lsiReader);
+        LeafReaderContext context = compositeReader.leaves().get(0);
+
+        return new TSDBLeafReaderWithContext(lsiReader, context, compositeReader, tempReader, indexWriter, directory);
     }
 
     /**

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregationBuilderTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregationBuilderTests.java
@@ -15,6 +15,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.tsdb.query.utils.TSDBStatsConstants;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -24,7 +25,7 @@ import java.util.Map;
  * Unit tests for TSDBStatsAggregationBuilder.
  *
  * <p>Covers: constructor validation, serialization roundtrip, XContent parsing/generation,
- * equals/hashCode, and shallow copy. Follows the test minimalism rule — minimum tests for ≥85% coverage.</p>
+ * equals/hashCode, and shallow copy. Follows the test minimalism rule -- minimum tests for >=85% coverage.</p>
  */
 public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
 
@@ -35,12 +36,19 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
     // ========== Constructor Tests ==========
 
     public void testConstructorWithValidParameters() {
-        TSDBStatsAggregationBuilder builder = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, true);
+        TSDBStatsAggregationBuilder builder = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
 
         assertEquals(TEST_NAME, builder.getName());
         assertEquals(MIN_TIMESTAMP, builder.getMinTimestamp());
         assertEquals(MAX_TIMESTAMP, builder.getMaxTimestamp());
         assertTrue(builder.isIncludeValueStats());
+        assertEquals(TSDBStatsConstants.DEDUP_MODE_INDEXED, builder.getDedupMode());
         assertEquals("tsdb_stats_agg", builder.getType());
         assertEquals(AggregationBuilder.BucketCardinality.NONE, builder.bucketCardinality());
     }
@@ -49,14 +57,14 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
         // max < min
         IllegalArgumentException ex1 = expectThrows(
             IllegalArgumentException.class,
-            () -> new TSDBStatsAggregationBuilder(TEST_NAME, 2000L, 1000L, true)
+            () -> new TSDBStatsAggregationBuilder(TEST_NAME, 2000L, 1000L, true, TSDBStatsConstants.DEDUP_MODE_INDEXED)
         );
         assertTrue(ex1.getMessage().contains("maxTimestamp must be greater than minTimestamp"));
 
         // max == min
         IllegalArgumentException ex2 = expectThrows(
             IllegalArgumentException.class,
-            () -> new TSDBStatsAggregationBuilder(TEST_NAME, 1000L, 1000L, true)
+            () -> new TSDBStatsAggregationBuilder(TEST_NAME, 1000L, 1000L, true, TSDBStatsConstants.DEDUP_MODE_INDEXED)
         );
         assertTrue(ex2.getMessage().contains("maxTimestamp must be greater than minTimestamp"));
     }
@@ -64,8 +72,14 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
     // ========== Serialization Tests ==========
 
     public void testSerializationRoundTrip() throws IOException {
-        // includeValueStats=true
-        TSDBStatsAggregationBuilder original = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, true);
+        // includeValueStats=true, indexed mode
+        TSDBStatsAggregationBuilder original = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
         TSDBStatsAggregationBuilder deserialized = serializeAndDeserialize(original);
 
         assertEquals(original, deserialized);
@@ -74,16 +88,30 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
         assertEquals(original.getMinTimestamp(), deserialized.getMinTimestamp());
         assertEquals(original.getMaxTimestamp(), deserialized.getMaxTimestamp());
         assertEquals(original.isIncludeValueStats(), deserialized.isIncludeValueStats());
+        assertEquals(original.getDedupMode(), deserialized.getDedupMode());
 
-        // includeValueStats=false
-        TSDBStatsAggregationBuilder original2 = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, false);
+        // includeValueStats=false, recomputed mode
+        TSDBStatsAggregationBuilder original2 = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            false,
+            TSDBStatsConstants.DEDUP_MODE_RECOMPUTED
+        );
         TSDBStatsAggregationBuilder deserialized2 = serializeAndDeserialize(original2);
         assertEquals(original2, deserialized2);
         assertFalse(deserialized2.isIncludeValueStats());
+        assertEquals(TSDBStatsConstants.DEDUP_MODE_RECOMPUTED, deserialized2.getDedupMode());
     }
 
     public void testSerializationWithEdgeCaseTimestamps() throws IOException {
-        TSDBStatsAggregationBuilder original = new TSDBStatsAggregationBuilder(TEST_NAME, Long.MIN_VALUE, Long.MAX_VALUE, true);
+        TSDBStatsAggregationBuilder original = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            Long.MIN_VALUE,
+            Long.MAX_VALUE,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
         TSDBStatsAggregationBuilder deserialized = serializeAndDeserialize(original);
 
         assertEquals(original, deserialized);
@@ -94,7 +122,13 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
     // ========== XContent Tests ==========
 
     public void testXContentGeneration() throws IOException {
-        TSDBStatsAggregationBuilder builder = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, true);
+        TSDBStatsAggregationBuilder builder = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
 
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
         builder.internalXContent(xContentBuilder, null);
@@ -103,13 +137,14 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
         assertTrue(json.contains("\"min_timestamp\":" + MIN_TIMESTAMP));
         assertTrue(json.contains("\"max_timestamp\":" + MAX_TIMESTAMP));
         assertTrue(json.contains("\"include_value_stats\":true"));
+        assertTrue(json.contains("\"dedup_mode\":\"indexed\""));
     }
 
     public void testXContentParsing() throws IOException {
-        // Full round-trip: parse with all fields
+        // Full round-trip: parse with all fields including dedup_mode
         String json = String.format(
             Locale.ROOT,
-            "{\"min_timestamp\":%d,\"max_timestamp\":%d,\"include_value_stats\":true}",
+            "{\"min_timestamp\":%d,\"max_timestamp\":%d,\"include_value_stats\":true,\"dedup_mode\":\"recomputed\"}",
             MIN_TIMESTAMP,
             MAX_TIMESTAMP
         );
@@ -122,9 +157,10 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
             assertEquals(MIN_TIMESTAMP, parsed.getMinTimestamp());
             assertEquals(MAX_TIMESTAMP, parsed.getMaxTimestamp());
             assertTrue(parsed.isIncludeValueStats());
+            assertEquals(TSDBStatsConstants.DEDUP_MODE_RECOMPUTED, parsed.getDedupMode());
         }
 
-        // With include_value_stats=false
+        // Without dedup_mode (should default to "indexed")
         String json2 = String.format(
             Locale.ROOT,
             "{\"min_timestamp\":%d,\"max_timestamp\":%d,\"include_value_stats\":false}",
@@ -136,6 +172,7 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
             parser.nextToken();
             TSDBStatsAggregationBuilder parsed = TSDBStatsAggregationBuilder.parse(TEST_NAME, parser);
             assertFalse(parsed.isIncludeValueStats());
+            assertEquals(TSDBStatsConstants.DEDUP_MODE_INDEXED, parsed.getDedupMode());
         }
     }
 
@@ -195,16 +232,48 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
     // ========== Equals and HashCode Tests ==========
 
     public void testEqualsAndHashCode() {
-        TSDBStatsAggregationBuilder builder1 = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, true);
-        TSDBStatsAggregationBuilder builder2 = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, true);
-        TSDBStatsAggregationBuilder differentValueStats = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, false);
-        TSDBStatsAggregationBuilder differentMax = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, 3000L, true);
+        TSDBStatsAggregationBuilder builder1 = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+        TSDBStatsAggregationBuilder builder2 = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+        TSDBStatsAggregationBuilder differentValueStats = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            false,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+        TSDBStatsAggregationBuilder differentMax = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            3000L,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+        TSDBStatsAggregationBuilder differentDedupMode = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_RECOMPUTED
+        );
 
         // equals
         assertEquals(builder1, builder2);
         assertEquals(builder1, builder1);
         assertNotEquals(builder1, differentValueStats);
         assertNotEquals(builder1, differentMax);
+        assertNotEquals(builder1, differentDedupMode);
         assertNotEquals(builder1, null);
         assertNotEquals(builder1, new Object());
 
@@ -215,7 +284,13 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
     // ========== Shallow Copy Tests ==========
 
     public void testShallowCopy() {
-        TSDBStatsAggregationBuilder original = new TSDBStatsAggregationBuilder(TEST_NAME, MIN_TIMESTAMP, MAX_TIMESTAMP, true);
+        TSDBStatsAggregationBuilder original = new TSDBStatsAggregationBuilder(
+            TEST_NAME,
+            MIN_TIMESTAMP,
+            MAX_TIMESTAMP,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_RECOMPUTED
+        );
         org.opensearch.search.aggregations.AggregatorFactories.Builder subFactoriesBuilder =
             new org.opensearch.search.aggregations.AggregatorFactories.Builder();
 
@@ -225,6 +300,7 @@ public class TSDBStatsAggregationBuilderTests extends OpenSearchTestCase {
         assertEquals(original.getMinTimestamp(), copy.getMinTimestamp());
         assertEquals(original.getMaxTimestamp(), copy.getMaxTimestamp());
         assertEquals(original.isIncludeValueStats(), copy.isIncludeValueStats());
+        assertEquals(original.getDedupMode(), copy.getDedupMode());
         assertNotSame(original, copy);
 
         // With metadata

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorFactoryTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorFactoryTests.java
@@ -13,6 +13,7 @@ import org.opensearch.search.aggregations.AggregatorFactories;
 import org.opensearch.search.aggregations.CardinalityUpperBound;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.tsdb.query.utils.TSDBStatsConstants;
 
 import java.util.Map;
 
@@ -146,7 +147,8 @@ public class TSDBStatsAggregatorFactoryTests extends OpenSearchTestCase {
                 Map.of(), // metadata
                 minTimestamp,
                 maxTimestamp,
-                includeValueStats
+                includeValueStats,
+                TSDBStatsConstants.DEDUP_MODE_RECOMPUTED
             );
         } catch (Exception e) {
             throw new RuntimeException("Failed to create factory for test", e);

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorTests.java
@@ -146,17 +146,14 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         aggregator1.close();
 
         // Test 2: Non-overlapping time range (should prune)
+        // Use CCI reader because LSI always sets maxTimestamp=Long.MAX_VALUE, breaking pruning tests
         long queryMinTimestamp = 1000L;
         long queryMaxTimestamp = 5000L;
         TSDBStatsAggregator aggregator2 = createAggregator("test", queryMinTimestamp, queryMaxTimestamp, true);
 
         long leafMinTimestamp = 6000L;
         long leafMaxTimestamp = 10000L;
-        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(
-            leafMinTimestamp,
-            leafMaxTimestamp,
-            null
-        );
+        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockCCIReaderWithLabels(leafMinTimestamp, leafMaxTimestamp, null);
         LeafBucketCollector mockSubCollector2 = mock(LeafBucketCollector.class);
 
         LeafBucketCollector result1 = aggregator2.getLeafCollector(readerCtx1.context, mockSubCollector2);
@@ -170,7 +167,7 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
 
         long leafMinTimestamp2 = 2000L;
         long leafMaxTimestamp2 = 6000L;
-        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(
+        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockCCIReaderWithLabels(
             leafMinTimestamp2,
             leafMaxTimestamp2,
             null
@@ -189,7 +186,7 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
 
         long leafMinTimestamp3 = 0L;
         long leafMaxTimestamp3 = 999L;
-        TSDBLeafReaderWithContext readerCtx3 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(
+        TSDBLeafReaderWithContext readerCtx3 = AggregatorTestUtils.createMockCCIReaderWithLabels(
             leafMinTimestamp3,
             leafMaxTimestamp3,
             null
@@ -216,7 +213,7 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         labels.put("host", "server1");
         labels.put("env", "prod");
 
-        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels);
+        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels);
 
         try {
             // Act
@@ -256,16 +253,8 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         // Same labels = same stableHash = dedup
         Map<String, String> sameLabels = Map.of("service", "api");
 
-        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(
-            minTimestamp,
-            maxTimestamp,
-            sameLabels
-        );
-        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(
-            minTimestamp,
-            maxTimestamp,
-            sameLabels
-        );
+        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, sameLabels);
+        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, sameLabels);
 
         try {
             // Act - Collect from first document (should process), then second with SAME labels (should skip)
@@ -301,7 +290,7 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
 
         Map<String, String> labels = Map.of("service", "api", "region", "us-west");
 
-        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels);
+        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels);
 
         try {
             // Act
@@ -332,7 +321,7 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
 
         Map<String, String> labels = Map.of("service", "api");
 
-        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels);
+        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels);
 
         try {
             // Act
@@ -365,8 +354,8 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         Map<String, String> labels1 = Map.of("service", "api", "host", "server1");
         Map<String, String> labels2 = Map.of("service", "web", "host", "server2");
 
-        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels1);
-        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels2);
+        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels1);
+        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels2);
 
         try {
             // Act - Collect from both documents
@@ -418,8 +407,8 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         Map<String, String> labels1 = Map.of("service", "api", "host", "server1");
         Map<String, String> labels2 = Map.of("service", "api", "host", "server2");
 
-        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels1);
-        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, labels2);
+        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels1);
+        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockLSIReaderWithLabels(minTimestamp, maxTimestamp, labels2);
 
         try {
             LeafBucketCollector collector1 = aggregator.getLeafCollector(readerCtx1.context, LeafBucketCollector.NO_OP_COLLECTOR);
@@ -452,11 +441,13 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
 
     // ========== Indexed Dedup Mode Tests ==========
 
-    public void testIndexedDedupModeWithUnsupportedReaderThrows() throws IOException {
-        // When dedupMode=indexed but the reader is not LiveSeriesIndexLeafReader or ClosedChunkIndexLeafReader,
-        // TSDBStatsLeafBucketCollector constructor should throw IOException.
+    public void testIndexedDedupModeWithCCIReader() throws IOException {
+        // Indexed mode with ClosedChunkIndexLeafReader reads seriesId from "labels_hash" field
         long minTimestamp = 1000L;
         long maxTimestamp = 5000L;
+        long seriesId = 12345L;
+        Map<String, String> labels = Map.of("service", "api", "host", "server1");
+
         TSDBStatsAggregator aggregator = createAggregatorWithDedupMode(
             "test",
             minTimestamp,
@@ -465,16 +456,105 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
             TSDBStatsConstants.DEDUP_MODE_INDEXED
         );
 
-        // The mock reader from AggregatorTestUtils is an anonymous TSDBLeafReader subclass,
-        // which is neither LiveSeriesIndexLeafReader nor ClosedChunkIndexLeafReader.
-        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, null);
-        LeafBucketCollector mockSubCollector = mock(LeafBucketCollector.class);
+        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockCCIReaderWithLabels(
+            minTimestamp,
+            maxTimestamp,
+            labels,
+            seriesId
+        );
 
         try {
-            IOException ex = expectThrows(IOException.class, () -> aggregator.getLeafCollector(readerCtx.context, mockSubCollector));
-            assertTrue("Exception should mention unsupported reader type", ex.getMessage().contains("Unsupported TSDBLeafReader type"));
+            LeafBucketCollector collector = aggregator.getLeafCollector(readerCtx.context, LeafBucketCollector.NO_OP_COLLECTOR);
+            collector.collect(0, 0);
+            InternalAggregation result = aggregator.buildAggregation(0);
+
+            InternalTSDBStats stats = reduceToCoordinator(result);
+            assertEquals("Should have 1 unique series", 1L, stats.getNumSeries().longValue());
+            assertEquals("Should have 2 label keys", 2, stats.getLabelStats().size());
+            assertTrue("Should contain 'service'", stats.getLabelStats().containsKey("service"));
         } finally {
             readerCtx.close();
+            aggregator.close();
+        }
+    }
+
+    public void testIndexedDedupModeWithLSIReader() throws IOException {
+        // Indexed mode with LiveSeriesIndexLeafReader reads seriesId from "reference" field
+        long minTimestamp = 1000L;
+        long maxTimestamp = 5000L;
+        long seriesId = 67890L;
+        Map<String, String> labels = Map.of("service", "web");
+
+        TSDBStatsAggregator aggregator = createAggregatorWithDedupMode(
+            "test",
+            minTimestamp,
+            maxTimestamp,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+
+        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockLSIReaderWithLabels(
+            minTimestamp,
+            maxTimestamp,
+            labels,
+            seriesId
+        );
+
+        try {
+            LeafBucketCollector collector = aggregator.getLeafCollector(readerCtx.context, LeafBucketCollector.NO_OP_COLLECTOR);
+            collector.collect(0, 0);
+            InternalAggregation result = aggregator.buildAggregation(0);
+
+            InternalTSDBStats stats = reduceToCoordinator(result);
+            assertEquals("Should have 1 unique series", 1L, stats.getNumSeries().longValue());
+            assertEquals("service:web count should be 1", 1L, stats.getLabelStats().get("service").valuesStats().get("web").longValue());
+        } finally {
+            readerCtx.close();
+            aggregator.close();
+        }
+    }
+
+    public void testIndexedDedupModeDeduplicatesSameSeriesId() throws IOException {
+        // Two CCI segments with the same seriesId → second should be deduped without decoding labels
+        long minTimestamp = 1000L;
+        long maxTimestamp = 5000L;
+        long sameSeriesId = 99999L;
+
+        TSDBStatsAggregator aggregator = createAggregatorWithDedupMode(
+            "test",
+            minTimestamp,
+            maxTimestamp,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+
+        Map<String, String> labels = Map.of("service", "api");
+        TSDBLeafReaderWithContext readerCtx1 = AggregatorTestUtils.createMockCCIReaderWithLabels(
+            minTimestamp,
+            maxTimestamp,
+            labels,
+            sameSeriesId
+        );
+        TSDBLeafReaderWithContext readerCtx2 = AggregatorTestUtils.createMockCCIReaderWithLabels(
+            minTimestamp,
+            maxTimestamp,
+            labels,
+            sameSeriesId
+        );
+
+        try {
+            LeafBucketCollector c1 = aggregator.getLeafCollector(readerCtx1.context, LeafBucketCollector.NO_OP_COLLECTOR);
+            c1.collect(0, 0);
+
+            LeafBucketCollector c2 = aggregator.getLeafCollector(readerCtx2.context, LeafBucketCollector.NO_OP_COLLECTOR);
+            c2.collect(0, 0);
+
+            InternalAggregation result = aggregator.buildAggregation(0);
+            InternalTSDBStats stats = reduceToCoordinator(result);
+            assertEquals("Should have 1 unique series (second deduped by indexed seriesId)", 1L, stats.getNumSeries().longValue());
+        } finally {
+            readerCtx1.close();
+            readerCtx2.close();
             aggregator.close();
         }
     }

--- a/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/aggregator/TSDBStatsAggregatorTests.java
@@ -23,6 +23,7 @@ import org.opensearch.search.aggregations.pipeline.PipelineAggregator;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.tsdb.query.aggregator.AggregatorTestUtils.TSDBLeafReaderWithContext;
+import org.opensearch.tsdb.query.utils.TSDBStatsConstants;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -449,6 +450,35 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         }
     }
 
+    // ========== Indexed Dedup Mode Tests ==========
+
+    public void testIndexedDedupModeWithUnsupportedReaderThrows() throws IOException {
+        // When dedupMode=indexed but the reader is not LiveSeriesIndexLeafReader or ClosedChunkIndexLeafReader,
+        // TSDBStatsLeafBucketCollector constructor should throw IOException.
+        long minTimestamp = 1000L;
+        long maxTimestamp = 5000L;
+        TSDBStatsAggregator aggregator = createAggregatorWithDedupMode(
+            "test",
+            minTimestamp,
+            maxTimestamp,
+            true,
+            TSDBStatsConstants.DEDUP_MODE_INDEXED
+        );
+
+        // The mock reader from AggregatorTestUtils is an anonymous TSDBLeafReader subclass,
+        // which is neither LiveSeriesIndexLeafReader nor ClosedChunkIndexLeafReader.
+        TSDBLeafReaderWithContext readerCtx = AggregatorTestUtils.createMockTSDBLeafReaderWithLabels(minTimestamp, maxTimestamp, null);
+        LeafBucketCollector mockSubCollector = mock(LeafBucketCollector.class);
+
+        try {
+            IOException ex = expectThrows(IOException.class, () -> aggregator.getLeafCollector(readerCtx.context, mockSubCollector));
+            assertTrue("Exception should mention unsupported reader type", ex.getMessage().contains("Unsupported TSDBLeafReader type"));
+        } finally {
+            readerCtx.close();
+            aggregator.close();
+        }
+    }
+
     // ========== Helper Methods ==========
 
     /**
@@ -473,6 +503,22 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         return createAggregatorWithMetadata(name, minTimestamp, maxTimestamp, includeValueStats, Map.of());
     }
 
+    private TSDBStatsAggregator createAggregatorWithDedupMode(
+        String name,
+        long minTimestamp,
+        long maxTimestamp,
+        boolean includeValueStats,
+        String dedupMode
+    ) throws IOException {
+        CircuitBreakerService circuitBreakerService = new NoneCircuitBreakerService();
+        BigArrays bigArrays = new BigArrays(null, circuitBreakerService, "test");
+
+        SearchContext searchContext = mock(SearchContext.class);
+        when(searchContext.bigArrays()).thenReturn(bigArrays);
+
+        return new TSDBStatsAggregator(name, searchContext, null, minTimestamp, maxTimestamp, includeValueStats, dedupMode, Map.of());
+    }
+
     private TSDBStatsAggregator createAggregatorWithMetadata(
         String name,
         long minTimestamp,
@@ -486,6 +532,15 @@ public class TSDBStatsAggregatorTests extends OpenSearchTestCase {
         SearchContext searchContext = mock(SearchContext.class);
         when(searchContext.bigArrays()).thenReturn(bigArrays);
 
-        return new TSDBStatsAggregator(name, searchContext, null, minTimestamp, maxTimestamp, includeValueStats, metadata);
+        return new TSDBStatsAggregator(
+            name,
+            searchContext,
+            null,
+            minTimestamp,
+            maxTimestamp,
+            includeValueStats,
+            TSDBStatsConstants.DEDUP_MODE_RECOMPUTED,
+            metadata
+        );
     }
 }

--- a/src/test/java/org/opensearch/tsdb/query/rest/RestTSDBStatsActionTests.java
+++ b/src/test/java/org/opensearch/tsdb/query/rest/RestTSDBStatsActionTests.java
@@ -541,6 +541,54 @@ public class RestTSDBStatsActionTests extends OpenSearchTestCase {
         assertThat(channel.capturedResponse().content().utf8ToString(), containsString("Invalid format"));
     }
 
+    // ========== Dedup Mode Parameter Tests ==========
+
+    public void testDedupModeDefaultIsIndexed() throws Exception {
+        // No dedup_mode param → defaults to "indexed" (no error)
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath("/_tsdb/stats")
+            .withParams(Map.of("query", "fetch service:api"))
+            .build();
+        FakeRestChannel channel = new FakeRestChannel(request, true, 1);
+
+        action.handleRequest(request, channel, mockClient);
+
+        assertThat(channel.capturedResponse().status(), equalTo(RestStatus.OK));
+    }
+
+    public void testValidDedupModeParameters() throws Exception {
+        // dedup_mode=indexed should succeed
+        FakeRestRequest requestIndexed = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath("/_tsdb/stats")
+            .withParams(Map.of("query", "fetch service:api", "dedup_mode", "indexed"))
+            .build();
+        FakeRestChannel channelIndexed = new FakeRestChannel(requestIndexed, true, 1);
+        action.handleRequest(requestIndexed, channelIndexed, mockClient);
+        assertThat(channelIndexed.capturedResponse().status(), equalTo(RestStatus.OK));
+
+        // dedup_mode=recomputed should also succeed
+        FakeRestRequest requestRecomputed = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath("/_tsdb/stats")
+            .withParams(Map.of("query", "fetch service:api", "dedup_mode", "recomputed"))
+            .build();
+        FakeRestChannel channelRecomputed = new FakeRestChannel(requestRecomputed, true, 1);
+        action.handleRequest(requestRecomputed, channelRecomputed, mockClient);
+        assertThat(channelRecomputed.capturedResponse().status(), equalTo(RestStatus.OK));
+    }
+
+    public void testInvalidDedupModeReturnsError() throws Exception {
+        FakeRestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.GET)
+            .withPath("/_tsdb/stats")
+            .withParams(Map.of("query", "fetch service:api", "dedup_mode", "foo"))
+            .build();
+        FakeRestChannel channel = new FakeRestChannel(request, true, 1);
+
+        action.handleRequest(request, channel, mockClient);
+
+        assertThat(channel.capturedResponse().status(), equalTo(RestStatus.BAD_REQUEST));
+        assertThat(channel.capturedResponse().content().utf8ToString(), containsString("Invalid dedup_mode"));
+    }
+
     // ========== Combined Parameter Tests ==========
 
     public void testAllParametersTogether() throws Exception {


### PR DESCRIPTION
### Description
Add a new query parameter dedup_mode to control how the TSDBStatsAggregator constructs the seriesId used for deduplication. Two modes are supported:

- "indexed" (default): Reads pre-indexed numeric value from NumericDocValues (reference for LSI, labels_hash for CCI), avoiding binary label decoding for duplicate series.
- "recomputed": Decodes labels and calls stableHash() (existing behavior), useful during hash algorithm migrations.

The parameter flows through RestTSDBStatsAction -> TSDBStatsAggregationBuilder -> TSDBStatsAggregatorFactory -> TSDBStatsAggregator. Uses String constants following the existing format parameter pattern.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
