### PR TITLE
Fix reader refresh for continuous ingestion and CacheHelper NPE

### DIFF
--- a/src/main/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReader.java
+++ b/src/main/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReader.java
@@ -389,14 +389,16 @@ public class TSDBDirectoryReader extends DirectoryReader {
     }
 
     /*
-    * Return null to disable caching for multi-directory reader.
+    * Return a valid CacheHelper to prevent NullPointerException when the query cache
+    * is enabled. The query cache calls getReaderCacheHelper().addClosedListener(...)
+    * and throws NPE if null is returned.
+    *
+    * Delegates to the live series index reader which has a CacheHelper tied to the
+    * underlying Lucene reader lifecycle.
     * */
     @Override
     public CacheHelper getReaderCacheHelper() {
-        // Multi-directory readers should return null to disable caching.
-        // This is consistent with other OpenSearch multi-directory implementations
-        // and ensures that IndicesService.canCache() returns false.
-        return null;
+        return liveSeriesIndexDirectoryReader.getReaderCacheHelper();
     }
 
     /**

--- a/src/main/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderReferenceManager.java
+++ b/src/main/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderReferenceManager.java
@@ -233,8 +233,8 @@ public class TSDBDirectoryReaderReferenceManager extends ReferenceManager<OpenSe
             return reader;
         } else {
             log.info("No changes detected for refreshing the tsdb directory reader");
-            // No structural change - attempt lightweight refresh
-            OpenSearchDirectoryReader refreshedReader = (OpenSearchDirectoryReader) DirectoryReader.openIfChanged(referenceToRefresh);
+            liveSeriesIndexReaderManager.maybeRefreshBlocking();
+            final OpenSearchDirectoryReader refreshedReader = (OpenSearchDirectoryReader) DirectoryReader.openIfChanged(referenceToRefresh);
 
             // Only record refresh interval if an actual refresh occurred (not a no-op)
             if (refreshedReader != null) {

--- a/src/test/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderReferenceManagerTests.java
+++ b/src/test/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderReferenceManagerTests.java
@@ -1011,4 +1011,37 @@ public class TSDBDirectoryReaderReferenceManagerTests extends OpenSearchTestCase
             }
         }
     }
+
+    @Test
+    public void testRefreshPicksUpUncommittedLiveDocuments() throws IOException {
+        when(closedChunkIndexManager.getReaderManagersWithMetadata()).thenReturn(Arrays.asList(closedReaderManager1));
+
+        referenceManager = new TSDBDirectoryReaderReferenceManager(
+            liveReaderManager,
+            () -> 0L,
+            closedChunkIndexManager,
+            memChunkReader,
+            labelStorageType,
+            mmappedChunksManager,
+            shardId
+        );
+
+        int initialDocCount = withAcquiredReader(reader -> {
+            TSDBDirectoryReader initialTSDBReader = (TSDBDirectoryReader) reader.getDelegate();
+            return initialTSDBReader.numDocs();
+        });
+
+        liveWriter.addDocument(getLiveDoc("service=uncommitted,env=test", 2000L, 5000000L));
+
+        try {
+            referenceManager.maybeRefreshBlocking();
+        } catch (Exception e) {
+            fail("Refresh failed: " + e.getMessage());
+        }
+
+        withAcquiredReader(reader -> {
+            TSDBDirectoryReader newTSDBReader = (TSDBDirectoryReader) reader.getDelegate();
+            assertTrue("Uncommitted document should be visible after refresh", newTSDBReader.numDocs() > initialDocCount);
+        });
+    }
 }

--- a/src/test/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderTests.java
+++ b/src/test/java/org/opensearch/tsdb/core/reader/TSDBDirectoryReaderTests.java
@@ -903,7 +903,7 @@ public class TSDBDirectoryReaderTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testGetReaderCacheHelperReturnsNull() throws IOException {
+    public void testGetReaderCacheHelperDelegatesToLiveReader() throws IOException {
         tsdbDirectoryReader = new TSDBDirectoryReader(
             liveReader,
             () -> 0L,
@@ -914,7 +914,8 @@ public class TSDBDirectoryReaderTests extends OpenSearchTestCase {
             1L
         );
 
-        assertNull("CacheHelper should return null", tsdbDirectoryReader.getReaderCacheHelper());
+        assertNotNull(tsdbDirectoryReader.getReaderCacheHelper());
+        assertSame(liveReader.getReaderCacheHelper(), tsdbDirectoryReader.getReaderCacheHelper());
     }
 
     @Test


### PR DESCRIPTION
### Description                                                                                                                                       

Fix two bugs in the TSDB reader layer that prevent production use under continuous ingestion. The lightweight refresh path in `TSDBDirectoryReaderReferenceManager.refreshIfNeeded()` calls `DirectoryReader.openIfChanged()` without flushing the live series index writer first. During continuous ingestion where no structural changes occur, newly created series remain invisible to queries until a structural event or explicit _refresh API call. The fix adds `liveSeriesIndexReaderManager.maybeRefreshBlocking()` before `openIfChanged()` in the lightweight path, consistent with what the structural refresh path already does.

`TSDBDirectoryReader.getReaderCacheHelper()` returns `null`. OpenSearch query cache is enabled by default and calls                                   `getReaderCacheHelper().addClosedListener(...)` on every DirectoryReader during search, which throws NullPointerException. The fix delegates to `liveSeriesIndexDirectoryReader.getReaderCacheHelper()` which returns a valid CacheHelper tied to the underlying Lucene reader lifecycle.           

Both bugs were found during end to end testing of a Prometheus to TSDB ingestion pipeline under sustained load. Existing integration tests do not catch them because they batch ingest data with explicit _refresh calls and disable query cache in their templates. 
                                                                                                                                                    
### Issues Resolved                                                                                                                                   
                  
  Resolves #105                                                                                                                                     
  https://github.com/opensearch-project/time-series-db/issues/105
                                                                                                                                                    
### Check List                                                                                                                                        
  [ X ] New functionality includes testing.                                                                                                             
  [ X ] New functionality has a documentation issue. Please link to it in this PR.                                                                      
  [ X ] New functionality has javadoc added                                     
  [ X ] Commits are signed with a real name per the DCO                                                                                                 
                                                                                                                                                    
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.                                
  For more information on following Developer Certificate of Origin and signing off your commits, please check                                      
  https://github.com/opensearch-project/time-series-db/blob/main/CONTRIBUTING.md.