### PR TITLE
Add Michael Froh (msfroh) as maintainer and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @yupeng9 @philiplhchan @itschrispeck
+*   @yupeng9 @philiplhchan @itschrispeck @msfroh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,3 +9,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Yupeng Fu   | [yupeng9](https://github.com/yupeng9)                   | Uber        |
 | Philip Chan | [philiplhchan](https://github.com/philiplhchan)                   | Uber        |
 | Chris Peck  | [itschrispeck](https://github.com/itschrispeck)                   | Uber        |
+| Michael Froh | [msfroh](https://github.com/msfroh)                   | Apple       |


### PR DESCRIPTION
Adds Michael Froh (@msfroh, Apple) to `MAINTAINERS.md` and `.github/CODEOWNERS`.

Per https://github.com/opensearch-project/.github/issues/578

### Changes
- `.github/CODEOWNERS`: add `@msfroh` to the global owners line
- `MAINTAINERS.md`: add Michael Froh row to the Current Maintainers table