### PR TITLE
Add Srikanth Padakanti (srikanthpadakanti) as maintainer and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @yupeng9 @philiplhchan @itschrispeck @msfroh
+*   @yupeng9 @philiplhchan @itschrispeck @msfroh @srikanthpadakanti

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Philip Chan | [philiplhchan](https://github.com/philiplhchan)                   | Uber        |
 | Chris Peck  | [itschrispeck](https://github.com/itschrispeck)                   | Uber        |
 | Michael Froh | [msfroh](https://github.com/msfroh)                   | Apple       |
+| Srikanth Padakanti | [srikanthpadakanti](https://github.com/srikanthpadakanti)                   | Apple       |


### PR DESCRIPTION
Adds Srikanth Padakanti (@srikanthpadakanti, Apple) to `MAINTAINERS.md` and `.github/CODEOWNERS`.

### Changes
- `.github/CODEOWNERS`: add `@srikanthpadakanti` to the global owners line
- `MAINTAINERS.md`: add Srikanth Padakanti row to the Current Maintainers table